### PR TITLE
Fix #100 - Ignore communication on unknown channels (in HID transport protocol)

### DIFF
--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -37,14 +37,14 @@ impl U2FHIDInit {
         T: U2FDevice + io::Read,
     {
         let mut frame = [0u8; HID_RPT_SIZE];
-        let count = dev.read(&mut frame)?;
+        let mut count = dev.read(&mut frame)?;
+
+        while dev.get_cid() != &frame[..4] {
+            count = dev.read(&mut frame)?;
+        }
 
         if count != HID_RPT_SIZE {
             return Err(io_err("invalid init packet"));
-        }
-
-        if dev.get_cid() != &frame[..4] {
-            return Err(io_err("invalid channel id"));
         }
 
         let cap = (frame[5] as usize) << 8 | (frame[6] as usize);
@@ -97,14 +97,14 @@ impl U2FHIDCont {
         T: U2FDevice + io::Read,
     {
         let mut frame = [0u8; HID_RPT_SIZE];
-        let count = dev.read(&mut frame)?;
+        let mut count = dev.read(&mut frame)?;
+
+        while dev.get_cid() != &frame[..4] {
+            count = dev.read(&mut frame)?;
+        }
 
         if count != HID_RPT_SIZE {
             return Err(io_err("invalid cont packet"));
-        }
-
-        if dev.get_cid() != &frame[..4] {
-            return Err(io_err("invalid channel id"));
         }
 
         if seq != frame[4] {


### PR DESCRIPTION
The ctap over hid protocol spec allows for different applications to
communicate with the authenticator at the same time. This is done by
allocating a "channel" for each application. An application should
ignore messages coming on channels it does not know.
(see
https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#usb-channels)

See also https://bugs.chromium.org/p/chromium/issues/detail?id=998452
for a similar bug which was fixed in chrome.