### PR TITLE
Add OpenBSD support to authenticator-rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ extern crate bindgen;
 use std::path::PathBuf;
 
 #[cfg(any(not(target_os = "linux"), not(feature = "binding-recompile")))]
-fn main () {}
+fn main() {}
 
 #[cfg(all(target_os = "linux", feature = "binding-recompile"))]
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ extern crate devd_rs;
 #[path = "freebsd/mod.rs"]
 pub mod platform;
 
+#[cfg(any(target_os = "openbsd"))]
+#[path = "openbsd/mod.rs"]
+pub mod platform;
+
 #[cfg(any(target_os = "macos"))]
 extern crate core_foundation;
 
@@ -36,6 +40,7 @@ pub mod platform;
 #[cfg(not(any(
     target_os = "linux",
     target_os = "freebsd",
+    target_os = "openbsd",
     target_os = "macos",
     target_os = "windows"
 )))]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -5,6 +5,6 @@
 pub mod device;
 pub mod transaction;
 
-mod hidwrapper;
 mod hidraw;
+mod hidwrapper;
 mod monitor;

--- a/src/openbsd/device.rs
+++ b/src/openbsd/device.rs
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate libc;
+
+use std::ffi::OsString;
+use std::io::{Read, Result, Write};
+use std::mem;
+
+use consts::CID_BROADCAST;
+use platform::monitor::FidoDev;
+use u2ftypes::U2FDevice;
+use util::{from_unix_result, io_err};
+
+#[derive(Debug)]
+pub struct Device {
+    path: OsString,
+    fd: libc::c_int,
+    cid: [u8; 4],
+    out_len: usize,
+}
+
+impl Device {
+    pub fn new(fido: FidoDev) -> Result<Self> {
+        debug!("device found: {:?}", fido);
+        Ok(Self {
+            path: fido.os_path,
+            fd: fido.fd,
+            cid: CID_BROADCAST,
+            out_len: 64,
+        })
+    }
+
+    pub fn is_u2f(&mut self) -> bool {
+        debug!("device {:?} is U2F/FIDO", self.path);
+
+        // From OpenBSD's libfido2 in 6.6-current:
+        // "OpenBSD (as of 201910) has a bug that causes it to lose
+        // track of the DATA0/DATA1 sequence toggle across uhid device
+        // open and close. This is a terrible hack to work around it."
+        match self.ping() {
+            Ok(_) => true,
+            Err(err) => {
+                debug!("device {:?} is not responding: {}", self.path, err);
+                false
+            }
+        }
+    }
+
+    fn ping(&mut self) -> Result<()> {
+        let capacity = 256;
+
+        for _ in 0..10 {
+            let mut data = vec![0u8; capacity];
+
+            // Send 1 byte ping
+            self.write_all(&[0, 0xff, 0xff, 0xff, 0xff, 0x81, 0, 1])?;
+
+            // Wait for response
+            let mut pfd: libc::pollfd = unsafe { mem::zeroed() };
+            pfd.fd = self.fd;
+            pfd.events = libc::POLLIN;
+            if from_unix_result(unsafe { libc::poll(&mut pfd, 1, 100) })? == 0 {
+                debug!("device {:?} timeout", self.path);
+                continue;
+            }
+
+            // Read response
+            self.read(&mut data[..])?;
+
+            return Ok(());
+        }
+
+        Err(io_err("no response from device"))
+    }
+}
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        // Close the fd, ignore any errors.
+        let _ = unsafe { libc::close(self.fd) };
+        debug!("device {:?} closed", self.path);
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Device) -> bool {
+        self.path == other.path
+    }
+}
+
+impl Read for Device {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let buf_ptr = buf.as_mut_ptr() as *mut libc::c_void;
+        let rv = unsafe { libc::read(self.fd, buf_ptr, buf.len()) };
+        from_unix_result(rv as usize)
+    }
+}
+
+impl Write for Device {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // Always skip the first byte (report number)
+        let data = &buf[1..];
+        let data_ptr = data.as_ptr() as *const libc::c_void;
+        let rv = unsafe { libc::write(self.fd, data_ptr, data.len()) };
+        Ok(from_unix_result(rv as usize)? + 1)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl U2FDevice for Device {
+    fn get_cid(&self) -> &[u8; 4] {
+        &self.cid
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
+    }
+}

--- a/src/openbsd/mod.rs
+++ b/src/openbsd/mod.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod device;
+pub mod transaction;
+
+mod monitor;

--- a/src/openbsd/monitor.rs
+++ b/src/openbsd/monitor.rs
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::ffi::{CString, OsString};
+use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use runloop::RunLoop;
+use util::from_unix_result;
+
+const POLL_TIMEOUT: u64 = 500;
+
+#[derive(Debug)]
+pub struct FidoDev {
+    pub fd: RawFd,
+    pub os_path: OsString,
+}
+
+pub struct Monitor<F>
+where
+    F: Fn(FidoDev, &dyn Fn() -> bool) + Sync,
+{
+    runloops: HashMap<OsString, RunLoop>,
+    new_device_cb: Arc<F>,
+}
+
+impl<F> Monitor<F>
+where
+    F: Fn(FidoDev, &dyn Fn() -> bool) + Send + Sync + 'static,
+{
+    pub fn new(new_device_cb: F) -> Self {
+        Self {
+            runloops: HashMap::new(),
+            new_device_cb: Arc::new(new_device_cb),
+        }
+    }
+
+    pub fn run(&mut self, alive: &dyn Fn() -> bool) -> io::Result<()> {
+        // Loop until we're stopped by the controlling thread, or fail.
+        while alive() {
+            // Iterate the first 10 fido(4) devices.
+            for path in (0..10)
+                .map(|unit| PathBuf::from(&format!("/dev/fido/{}", unit)))
+                .filter(|path| path.exists())
+            {
+                let os_path = path.as_os_str().to_os_string();
+                let cstr = CString::new(os_path.as_bytes())?;
+
+                // Try to open the device.
+                let fd = unsafe { libc::open(cstr.as_ptr(), libc::O_RDWR) };
+                match from_unix_result(fd) {
+                    Ok(fd) => {
+                        // The device is available if it can be opened.
+                        self.add_device(FidoDev { fd, os_path });
+                    }
+                    Err(ref err) if err.raw_os_error() == Some(libc::EBUSY) => {
+                        // The device is available but currently in use.
+                    }
+                    _ => {
+                        // libc::ENODEV or any other error.
+                        self.remove_device(os_path);
+                    }
+                }
+            }
+
+            thread::sleep(Duration::from_millis(POLL_TIMEOUT));
+        }
+
+        // Remove all tracked devices.
+        self.remove_all_devices();
+
+        Ok(())
+    }
+
+    fn add_device(&mut self, fido: FidoDev) {
+        if !self.runloops.contains_key(&fido.os_path) {
+            let f = self.new_device_cb.clone();
+            let key = fido.os_path.clone();
+
+            let runloop = RunLoop::new(move |alive| {
+                if alive() {
+                    f(fido, alive);
+                }
+            });
+
+            if let Ok(runloop) = runloop {
+                self.runloops.insert(key, runloop);
+            }
+        }
+    }
+
+    fn remove_device(&mut self, path: OsString) {
+        if let Some(runloop) = self.runloops.remove(&path) {
+            runloop.cancel();
+        }
+    }
+
+    fn remove_all_devices(&mut self) {
+        while !self.runloops.is_empty() {
+            let path = self.runloops.keys().next().unwrap().clone();
+            self.remove_device(path);
+        }
+    }
+}

--- a/src/openbsd/transaction.rs
+++ b/src/openbsd/transaction.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use platform::monitor::{FidoDev, Monitor};
+use runloop::RunLoop;
+use util::OnceCallback;
+
+pub struct Transaction {
+    // Handle to the thread loop.
+    thread: Option<RunLoop>,
+}
+
+impl Transaction {
+    pub fn new<F, T>(
+        timeout: u64,
+        callback: OnceCallback<T>,
+        new_device_cb: F,
+    ) -> Result<Self, ::Error>
+    where
+        F: Fn(FidoDev, &dyn Fn() -> bool) + Sync + Send + 'static,
+        T: 'static,
+    {
+        let thread = RunLoop::new_with_timeout(
+            move |alive| {
+                // Create a new device monitor.
+                let mut monitor = Monitor::new(new_device_cb);
+
+                // Start polling for new devices.
+                try_or!(monitor.run(alive), |_| callback.call(Err(::Error::Unknown)));
+
+                // Send an error, if the callback wasn't called already.
+                callback.call(Err(::Error::NotAllowed));
+            },
+            timeout,
+        )
+        .map_err(|_| ::Error::Unknown)?;
+
+        Ok(Self {
+            thread: Some(thread),
+        })
+    }
+
+    pub fn cancel(&mut self) {
+        // This must never be None.
+        self.thread.take().unwrap().cancel();
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,6 +56,15 @@ pub fn from_unix_result<T: Signed>(rv: T) -> io::Result<T> {
     }
 }
 
+#[cfg(any(target_os = "openbsd"))]
+pub fn from_unix_result<T: Signed>(rv: T) -> io::Result<T> {
+    if rv.is_negative() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(rv)
+    }
+}
+
 pub fn io_err(msg: &str) -> io::Error {
     io::Error::new(io::ErrorKind::Other, msg)
 }


### PR DESCRIPTION
This implementation uses OpenBSD's fido(4) interface which provides restricted USB HID access to FIDO/U2F security keys.  fido(4) is a new driver in OpenBSD 6.7 (6.6-current at the time of this writing); running this code on older releases will simply not find the security keys which is OK as full backwards compatibility is not desired.

See also: http://man.openbsd.org/fido.4

We've also tested this as a patch for the Mozilla Firefox port in OpenBSD, see:
https://marc.info/?l=openbsd-ports&m=157666694220206

Please note that I decided to pass the device as an opened file descriptor instead of a device name to prevent a possible TOCTOU issue. This is different to the existing FreeBSD backend.