### PR TITLE
Fix race condition causing repeated sign requests

### DIFF
--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -171,7 +171,7 @@ impl StateMachine {
                 return;
             }
 
-            while alive() {
+            'outer: while alive() {
                 // If the device matches none of the given key handles
                 // then just make it blink with bogus data.
                 if valid_handles.is_empty() {
@@ -190,7 +190,7 @@ impl StateMachine {
                                 key_handle.credential.clone(),
                                 bytes,
                             )));
-                            break;
+                            break 'outer;
                         }
                     }
                 }


### PR DESCRIPTION
The `break` only caused the inner loop to break, so the Transaction would
continue until the StateMachine itself is cancelled by the U2FManager,
which only happens when it is dropped.

This means that there would be a period in which the sign request is fully
done, but the manager is not yet dropped in which one or more other sign
requests can execute.

Example:

```rust
let manager = U2FManager::new().unwrap();
    let flags = RegisterFlags::empty();

    let (tx, rx) = channel();
    manager
        .register(
            flags,
            15_000,
            chall_bytes.clone(),
            app_bytes.clone(),
            vec![],
            move |rv| {
                tx.send(rv.unwrap()).unwrap();
            },
        )
        .unwrap();

    let register_data = try_or!(rx.recv(), |_| {
        panic!("Problem receiving, unable to continue");
    });
    println!("Register result: {}", base64::encode(&register_data));
    println!("Asking a security key to sign now, with the data from the register...");
    let credential = u2f_get_key_handle_from_register_response(&register_data).unwrap();
    let key_handle = KeyHandle {
        credential,
        transports: AuthenticatorTransports::empty(),
    };

    let flags = SignFlags::empty();
    let (tx, rx) = channel();
    manager
        .sign(
            flags,
            15_000,
            chall_bytes.clone(),
            vec![app_bytes.clone()],
            vec![key_handle],
            move |rv| {
                tx.send(rv.unwrap()).unwrap();
            },
        )
        .unwrap();

    let (_, handle_used, sign_data) = try_or!(rx.recv(), |_| {
        println!("Problem receiving");
    });
    println!("Sign result: {}", base64::encode(&sign_data));
    println!("Key handle used: {}", base64::encode(&handle_used));

    println!("Starting wait...");
    thread::sleep(Duration::from_millis(10000));

    // The operation is finished, so we should be idling.
    // Instead we are spamming the u2f device with repeated sign requests!

    // Just here to prevent the manager from being dropped
    let flags = RegisterFlags::empty();
    let (tx, rx) = channel();
    manager
        .register(
            flags,
            15_000,
            chall_bytes.clone(),
            app_bytes.clone(),
            vec![],
            move |rv| {
                tx.send(rv.unwrap()).unwrap();
            },
        );
    println!("Done");
```