### PR TITLE
Add NetBSD support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This is a cross-platform library for interacting with Security Key-type devices via Rust.
 
-* **Supported Platforms**: Windows, Linux, FreeBSD, OpenBSD, and macOS.
+* **Supported Platforms**: Windows, Linux, FreeBSD, NetBSD, OpenBSD, and macOS.
 * **Supported Transports**: USB HID.
 * **Supported Protocols**: [FIDO U2F over USB](https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html). [CTAP2 support](https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html) is forthcoming, with work being done in the **unstable** [`ctap2` branch](https://github.com/mozilla/authenticator-rs/tree/ctap2).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod util;
 
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "netbsd"))]
 pub mod hidproto;
 
 #[cfg(any(target_os = "linux"))]
@@ -20,6 +20,10 @@ extern crate devd_rs;
 
 #[cfg(any(target_os = "freebsd"))]
 #[path = "freebsd/mod.rs"]
+pub mod platform;
+
+#[cfg(any(target_os = "netbsd"))]
+#[path = "netbsd/mod.rs"]
 pub mod platform;
 
 #[cfg(any(target_os = "openbsd"))]
@@ -41,6 +45,7 @@ pub mod platform;
     target_os = "linux",
     target_os = "freebsd",
     target_os = "openbsd",
+    target_os = "netbsd",
     target_os = "macos",
     target_os = "windows"
 )))]

--- a/src/netbsd/device.rs
+++ b/src/netbsd/device.rs
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate libc;
+
+use std::mem;
+use std::io::Read;
+use std::io::Write;
+use std::io;
+
+use consts::CID_BROADCAST;
+use consts::HID_RPT_SIZE;
+use platform::fd::Fd;
+use platform::uhid;
+use u2ftypes::U2FDevice;
+use util::io_err;
+
+#[derive(Debug)]
+pub struct Device {
+    fd: Fd,
+    cid: [u8; 4],
+}
+
+impl Device {
+    pub fn new(fd: Fd) -> io::Result<Self> {
+        Ok(Self { fd, cid: CID_BROADCAST })
+    }
+
+    pub fn is_u2f(&mut self) -> bool {
+        if !uhid::is_u2f_device(&self.fd) {
+            return false;
+        }
+        // This step is not strictly necessary -- NetBSD puts fido
+        // devices into raw mode automatically by default, but in
+        // principle that might change, and this serves as a test to
+        // verify that we're running on a kernel with support for raw
+        // mode at all so we don't get confused issuing writes that try
+        // to set the report descriptor rather than transfer data on
+        // the output interrupt pipe as we need.
+        match uhid::hid_set_raw(&self.fd, true) {
+            Ok(_) => (),
+            Err(_) => return false,
+        }
+        if let Err(_) = self.ping() {
+            return false;
+        }
+        true
+    }
+
+    fn ping(&mut self) -> io::Result<()> {
+        for i in 0..10 {
+            let mut buf = vec![0u8; 1 + HID_RPT_SIZE];
+
+            buf[0] = 0;         // report number
+            buf[1] = 0xff;      // CID_BROADCAST
+            buf[2] = 0xff;
+            buf[3] = 0xff;
+            buf[4] = 0xff;
+            buf[5] = 0x81;      // ping
+            buf[6] = 0;
+            buf[7] = 1;         // one byte
+
+            self.write(&buf[..])?;
+
+            // Wait for response
+            let mut pfd: libc::pollfd = unsafe { mem::zeroed() };
+            pfd.fd = self.fd.fileno;
+            pfd.events = libc::POLLIN;
+            let nfds = unsafe { libc::poll(&mut pfd, 1, 100) };
+            if nfds == -1 {
+                return Err(io::Error::last_os_error());
+            }
+            if nfds == 0 {
+                debug!("device timeout {}", i);
+                continue;
+            }
+
+            // Read response
+            self.read(&mut buf[..])?;
+
+            return Ok(());
+        }
+
+        Err(io_err("no response from device"))
+    }
+}
+
+impl PartialEq for Device {
+    fn eq(&self, other: &Device) -> bool {
+        self.fd == other.fd
+    }
+}
+
+impl Read for Device {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let bufp = buf.as_mut_ptr() as *mut libc::c_void;
+        let nread = unsafe { libc::read(self.fd.fileno, bufp, buf.len()) };
+        if nread == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(nread as usize)
+    }
+}
+
+impl Write for Device {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Always skip the first byte (report number)
+        let data = &buf[1..];
+        let data_ptr = data.as_ptr() as *const libc::c_void;
+        let nwrit = unsafe {
+            libc::write(self.fd.fileno, data_ptr, data.len())
+        };
+        if nwrit == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        // Pretend we wrote the report number byte
+        Ok(nwrit as usize + 1)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl U2FDevice for Device {
+    fn get_cid<'a>(&'a self) -> &'a [u8; 4] {
+        &self.cid
+    }
+
+    fn set_cid(&mut self, cid: [u8; 4]) {
+        self.cid = cid;
+    }
+}

--- a/src/netbsd/fd.rs
+++ b/src/netbsd/fd.rs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate libc;
+
+use std::ffi::CString;
+use std::io;
+use std::mem;
+use std::os::raw::c_int;
+use std::os::unix::io::RawFd;
+
+#[derive(Debug)]
+pub struct Fd {
+    pub fileno: RawFd,
+}
+
+impl Fd {
+    pub fn open(path: &str, flags: c_int) -> io::Result<Fd> {
+        let cpath = CString::new(path.as_bytes())?;
+        let rv = unsafe { libc::open(cpath.as_ptr(), flags) };
+        if rv == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Fd { fileno: rv })
+    }
+}
+
+impl Drop for Fd {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.fileno) };
+    }
+}
+
+impl PartialEq for Fd {
+    fn eq(&self, other: &Fd) -> bool {
+        let mut st: libc::stat = unsafe { mem::zeroed() };
+        let mut sto: libc::stat = unsafe { mem::zeroed() };
+        if unsafe { libc::fstat(self.fileno, &mut st) } == -1 {
+            return false;
+        }
+        if unsafe { libc::fstat(other.fileno, &mut sto) } == -1 {
+            return false;
+        }
+        (st.st_dev == sto.st_dev) & (st.st_ino == sto.st_ino)
+    }
+}

--- a/src/netbsd/mod.rs
+++ b/src/netbsd/mod.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod device;
+pub mod transaction;
+
+mod fd;
+mod monitor;
+mod uhid;

--- a/src/netbsd/monitor.rs
+++ b/src/netbsd/monitor.rs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use runloop::RunLoop;
+
+use platform::fd::Fd;
+
+// XXX Should use drvctl, but it doesn't do pubsub properly yet so
+// DRVGETEVENT requires write access to /dev/drvctl.  Instead, for now,
+// just poll every 500ms.
+const POLL_TIMEOUT: u64 = 500;
+
+pub struct Monitor<F>
+where
+    F: Fn(Fd, &dyn Fn() -> bool) + Send + Sync + 'static,
+{
+    runloops: HashMap<OsString, RunLoop>,
+    new_device_cb: Arc<F>,
+}
+
+impl<F> Monitor<F>
+where
+    F: Fn(Fd, &dyn Fn() -> bool) + Send + Sync + 'static,
+{
+    pub fn new(new_device_cb: F) -> Self {
+        Self {
+            runloops: HashMap::new(),
+            new_device_cb: Arc::new(new_device_cb),
+        }
+    }
+
+    pub fn run(&mut self, alive: &dyn Fn() -> bool) -> io::Result<()> {
+        while alive() {
+            for n in 0..100 {
+                let uhidpath = format!("/dev/uhid{}", n);
+                match Fd::open(&uhidpath, libc::O_RDWR | libc::O_CLOEXEC) {
+                    Ok(uhid) => {
+                        self.add_device(uhid, OsString::from(&uhidpath));
+                    },
+                    Err(ref err) => {
+                        match err.raw_os_error() {
+                            Some(libc::EBUSY) => continue,
+                            Some(libc::ENOENT) => break,
+                            _ => self.remove_device(OsString::from(&uhidpath)),
+                        }
+                    },
+                }
+            }
+            thread::sleep(Duration::from_millis(POLL_TIMEOUT));
+        }
+        self.remove_all_devices();
+        Ok(())
+    }
+
+    fn add_device(&mut self, fd: Fd, path: OsString) {
+        let f = self.new_device_cb.clone();
+
+        let runloop = RunLoop::new(move |alive| {
+            if alive() {
+                f(fd, alive);
+            }
+        });
+
+        if let Ok(runloop) = runloop {
+            self.runloops.insert(path.clone(), runloop);
+        }
+    }
+
+    fn remove_device(&mut self, path: OsString) {
+        if let Some(runloop) = self.runloops.remove(&path) {
+            runloop.cancel();
+        }
+    }
+
+    fn remove_all_devices(&mut self) {
+        while !self.runloops.is_empty() {
+            let path = self.runloops.keys().next().unwrap().clone();
+            self.remove_device(path);
+        }
+    }
+}

--- a/src/netbsd/transaction.rs
+++ b/src/netbsd/transaction.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use runloop::RunLoop;
+use util::OnceCallback;
+
+use platform::fd::Fd;
+use platform::monitor::Monitor;
+
+pub struct Transaction {
+    // Handle to the thread loop.
+    thread: Option<RunLoop>,
+}
+
+impl Transaction {
+    pub fn new<F, T>(
+        timeout: u64,
+        callback: OnceCallback<T>,
+        new_device_cb: F,
+    ) -> Result<Self, ::Error>
+    where
+        F: Fn(Fd, &dyn Fn() -> bool) + Sync + Send + 'static,
+        T: 'static,
+    {
+        let thread = RunLoop::new_with_timeout(
+            move |alive| {
+                // Create a new device monitor.
+                let mut monitor = Monitor::new(new_device_cb);
+
+                // Start polling for new devices.
+                try_or!(monitor.run(alive), |_| callback.call(Err(::Error::Unknown)));
+
+                // Send an error, if the callback wasn't called already.
+                callback.call(Err(::Error::NotAllowed));
+            },
+            timeout,
+        )
+        .map_err(|_| ::Error::Unknown)?;
+
+        Ok(Self {
+            thread: Some(thread),
+        })
+    }
+
+    pub fn cancel(&mut self) {
+        // This must never be None.
+        self.thread.take().unwrap().cancel();
+    }
+}

--- a/src/netbsd/uhid.rs
+++ b/src/netbsd/uhid.rs
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate libc;
+
+use std::io;
+use std::mem;
+use std::os::raw::c_int;
+use std::os::raw::c_uchar;
+
+use hidproto::ReportDescriptor;
+use hidproto::has_fido_usage;
+use platform::fd::Fd;
+use util::io_err;
+
+/* sys/ioccom.h */
+
+const IOCPARM_MASK: u32 = 0x1fff;
+const IOCPARM_SHIFT: u32 = 16;
+const IOCGROUP_SHIFT: u32 = 8;
+
+//const IOC_VOID: u32 = 0x20000000;
+const IOC_OUT: u32 = 0x40000000;
+const IOC_IN: u32 = 0x80000000;
+//const IOC_INOUT: u32 = IOC_IN|IOC_OUT;
+
+macro_rules! ioctl {
+    ($dir:expr, $name:ident, $group:expr, $nr:expr, $ty:ty) => {
+        unsafe fn $name(fd: libc::c_int, val: *mut $ty)
+                -> io::Result<libc::c_int> {
+            let ioc = ($dir as u32)
+                | ((mem::size_of::<$ty>() as u32 & IOCPARM_MASK)
+                   << IOCPARM_SHIFT)
+                | (($group as u32) << IOCGROUP_SHIFT)
+                | ($nr as u32);
+            let rv = libc::ioctl(fd, ioc as libc::c_ulong, val);
+            if rv == -1 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(rv)
+        }
+    };
+}
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct usb_ctl_report_desc {
+    ucrd_size: c_int,
+    ucrd_data: [c_uchar; 1024],
+}
+
+ioctl!(IOC_OUT, usb_get_report_desc, b'U', 21, usb_ctl_report_desc);
+
+fn read_report_descriptor(fd: &Fd) -> io::Result<ReportDescriptor> {
+    let mut desc = unsafe { mem::zeroed() };
+    unsafe { usb_get_report_desc(fd.fileno, &mut desc) }?;
+    if desc.ucrd_size < 0 {
+        return Err(io_err("negative report descriptor size"));
+    }
+    let size = desc.ucrd_size as usize;
+    let value = Vec::from(&desc.ucrd_data[..size]);
+    Ok(ReportDescriptor { value })
+}
+
+pub fn is_u2f_device(fd: &Fd) -> bool {
+    match read_report_descriptor(fd) {
+        Ok(desc) => has_fido_usage(desc),
+        Err(_) => false,
+    }
+}
+
+ioctl!(IOC_IN, usb_hid_set_raw_ioctl, b'h', 2, c_int);
+
+pub fn hid_set_raw(fd: &Fd, raw: bool) -> io::Result<()> {
+    let mut raw_int: c_int = if raw { 1 } else { 0 };
+    unsafe { usb_hid_set_raw_ioctl(fd.fileno, &mut raw_int) }?;
+    Ok(())
+}


### PR DESCRIPTION
Kernel support in NetBSD for the necessary raw mode is not yet included in a release, but it's been committed to HEAD and should be included in NetBSD 9.1 and NetBSD 10.

https://mail-index.netbsd.org/source-changes/2020/03/02/msg114683.html
https://releng.netbsd.org/cgi-bin/req-9.cgi?show=1010