### PR TITLE
Windows fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
     export RUSTFLAGS="-Z sanitizer=address"
   fi
 - |
-  if [ "$TRAVIS_RUST_VERSION" == "stable" ] ; then
+  if [ "$TRAVIS_RUST_VERSION" == "stable" ] && [ "$TRAVIS_OS_NAME" == "linux" ] ; then
     echo "Running rustfmt"
     cargo fmt --all -- --check
     echo "Running clippy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
 - |
-  if [ "$TRAVIS_RUST_VERSION" == "nightly" ] && [ "$TRAVIS_OS_NAME" == "windows" ] ; then
+  if [ "$TRAVIS_RUST_VERSION" == "nightly" ] && [ "$TRAVIS_OS_NAME" == "linux" ] ; then
     export ASAN_OPTIONS="detect_odr_violation=1:leak_check_at_exit=0:detect_leaks=0"
     export RUSTFLAGS="-Z sanitizer=address"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
-sudo: false
+os:
+  - linux
+  - windows
+
 language: rust
-cache: cargo
 rust:
   - stable
-  - beta
   - nightly
+cache: cargo
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
 
@@ -16,18 +18,13 @@ addons:
       - build-essential
       - libudev-dev
 
-before_install:
-  - pkg-config --list-all
-  - pkg-config --libs libudev
-  - pkg-config --modversion libudev
-
 install:
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt
+  - rustup component add clippy
 
 script:
 - |
-  if [ "$TRAVIS_RUST_VERSION" == "nightly" ] ; then
+  if [ "$TRAVIS_RUST_VERSION" == "nightly" ] && [ "$TRAVIS_OS_NAME" == "windows" ] ; then
     export ASAN_OPTIONS="detect_odr_violation=1:leak_check_at_exit=0:detect_leaks=0"
     export RUSTFLAGS="-Z sanitizer=address"
   fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ devd-rs = "0.3"
 core-foundation = "0.9"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
-version = "0.3"
+version = "^0.3"
 features = [
     "handleapi",
     "hidclass",

--- a/src/windows/device.rs
+++ b/src/windows/device.rs
@@ -23,8 +23,8 @@ impl Device {
     pub fn new(path: String) -> io::Result<Self> {
         let file = OpenOptions::new().read(true).write(true).open(&path)?;
         Ok(Self {
-            path: path,
-            file: file,
+            path,
+            file,
             cid: CID_BROADCAST,
         })
     }

--- a/src/windows/monitor.rs
+++ b/src/windows/monitor.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 pub struct Monitor<F>
 where
-    F: Fn(String, &Fn() -> bool) + Sync,
+    F: Fn(String, &dyn Fn() -> bool) + Sync,
 {
     runloops: HashMap<String, RunLoop>,
     new_device_cb: Arc<F>,
@@ -21,7 +21,7 @@ where
 
 impl<F> Monitor<F>
 where
-    F: Fn(String, &Fn() -> bool) + Send + Sync + 'static,
+    F: Fn(String, &dyn Fn() -> bool) + Send + Sync + 'static,
 {
     pub fn new(new_device_cb: F) -> Self {
         Self {
@@ -30,7 +30,7 @@ where
         }
     }
 
-    pub fn run(&mut self, alive: &Fn() -> bool) -> io::Result<()> {
+    pub fn run(&mut self, alive: &dyn Fn() -> bool) -> io::Result<()> {
         let mut stored = HashSet::new();
 
         while alive() {

--- a/src/windows/transaction.rs
+++ b/src/windows/transaction.rs
@@ -18,7 +18,7 @@ impl Transaction {
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where
-        F: Fn(String, &Fn() -> bool) + Sync + Send + 'static,
+        F: Fn(String, &dyn Fn() -> bool) + Sync + Send + 'static,
         T: 'static,
     {
         let thread = RunLoop::new_with_timeout(

--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -128,9 +128,11 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut device_interface_data =
-            unsafe { mem::uninitialized::<setupapi::SP_DEVICE_INTERFACE_DATA>() };
-        device_interface_data.cbSize =
-            mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DATA>() as minwindef::UINT;
+            mem::MaybeUninit::<setupapi::SP_DEVICE_INTERFACE_DATA>::zeroed();
+        unsafe {
+            (*device_interface_data.as_mut_ptr()).cbSize =
+                mem::size_of::<setupapi::SP_DEVICE_INTERFACE_DATA>() as minwindef::UINT;
+        }
 
         let rv = unsafe {
             SetupDiEnumDeviceInterfaces(
@@ -138,7 +140,7 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
                 ptr::null_mut(),
                 &hidclass::GUID_DEVINTERFACE_HID,
                 self.index,
-                &mut device_interface_data,
+                device_interface_data.as_mut_ptr(),
             )
         };
         if rv == 0 {
@@ -150,7 +152,7 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
         unsafe {
             SetupDiGetDeviceInterfaceDetailW(
                 self.set.get(),
-                &mut device_interface_data,
+                device_interface_data.as_mut_ptr(),
                 ptr::null_mut(),
                 required_size,
                 &mut required_size,
@@ -170,7 +172,7 @@ impl<'a> Iterator for DeviceInfoSetIter<'a> {
         let rv = unsafe {
             SetupDiGetDeviceInterfaceDetailW(
                 self.set.get(),
-                &mut device_interface_data,
+                device_interface_data.as_mut_ptr(),
                 detail.get(),
                 required_size,
                 ptr::null_mut(),
@@ -247,18 +249,19 @@ impl DeviceCapabilities {
             return Err(io_err("HidD_GetPreparsedData failed!"));
         }
 
-        let mut caps: hidpi::HIDP_CAPS = unsafe { mem::uninitialized() };
-
+        let mut caps = mem::MaybeUninit::<hidpi::HIDP_CAPS>::uninit();
         unsafe {
-            let rv = HidP_GetCaps(preparsed_data, &mut caps);
+            let rv = HidP_GetCaps(preparsed_data, caps.as_mut_ptr());
             HidD_FreePreparsedData(preparsed_data);
 
             if rv != hidpi::HIDP_STATUS_SUCCESS {
                 return Err(io_err("HidP_GetCaps failed!"));
             }
-        }
 
-        Ok(Self { caps })
+            Ok(Self {
+                caps: caps.assume_init(),
+            })
+        }
     }
 
     pub fn usage(&self) -> hidusage::USAGE {


### PR DESCRIPTION
Fixes the following errors:
```
error: trait objects without an explicit `dyn` are deprecated
  --> src\windows\transaction.rs:21:24
   |
21 |         F: Fn(String, &Fn() -> bool) + Sync + Send + 'static,
   |                        ^^^^^^^^^^^^ help: use `dyn`: `dyn Fn() -> bool`
   |
   = note: `-D bare-trait-objects` implied by `-D warnings`

error: trait objects without an explicit `dyn` are deprecated
  --> src\windows\monitor.rs:16:20
   |
16 |     F: Fn(String, &Fn() -> bool) + Sync,
   |                    ^^^^^^^^^^^^ help: use `dyn`: `dyn Fn() -> bool`

error: trait objects without an explicit `dyn` are deprecated
  --> src\windows\monitor.rs:24:20
   |
24 |     F: Fn(String, &Fn() -> bool) + Send + Sync + 'static,
   |                    ^^^^^^^^^^^^ help: use `dyn`: `dyn Fn() -> bool`

error: trait objects without an explicit `dyn` are deprecated
  --> src\windows\monitor.rs:33:35
   |
33 |     pub fn run(&mut self, alive: &Fn() -> bool) -> io::Result<()> {
   |                                   ^^^^^^^^^^^^ help: use `dyn`: `dyn Fn() -> bool`
    Checking termcolor v1.1.0

error: redundant field names in struct initialization
  --> src\windows\device.rs:26:13
   |
26 |             path: path,
   |             ^^^^^^^^^^ help: replace it with: `path`
   |
   = note: `-D clippy::redundant-field-names` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

error: redundant field names in struct initialization
  --> src\windows\device.rs:27:13
   |
27 |             file: file,
   |             ^^^^^^^^^^ help: replace it with: `file`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

error: use of deprecated item 'std::mem::uninitialized': use `mem::MaybeUninit` instead
   --> src\windows\winapi.rs:131:22
    |
131 |             unsafe { mem::uninitialized::<setupapi::SP_DEVICE_INTERFACE_DATA>() };
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

error: use of deprecated item 'std::mem::uninitialized': use `mem::MaybeUninit` instead
   --> src\windows\winapi.rs:250:51
    |
250 |         let mut caps: hidpi::HIDP_CAPS = unsafe { mem::uninitialized() };
    |                                                   ^^^^^^^^^^^^^^^^^^
    Checking env_logger v0.6.2

error: aborting due to 8 previous errors
```