### PR TITLE
Rework callback to not use boxfnonce since rust 1.35.0 doesn't need it anymore 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ bindgen = { version = "^0.51", optional = true }
 rand = "0.7"
 log = "0.4"
 libc = "0.2"
-boxfnonce = "0.0.3"
 runloop = "0.1.0"
 bitflags = "1.0"
 

--- a/src/freebsd/transaction.rs
+++ b/src/freebsd/transaction.rs
@@ -5,7 +5,7 @@
 use platform::monitor::Monitor;
 use runloop::RunLoop;
 use std::ffi::OsString;
-use util::OnceCallback;
+use util::StateCallback;
 
 pub struct Transaction {
     // Handle to the thread loop.
@@ -15,7 +15,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ pub mod platform;
 #[path = "stub/mod.rs"]
 pub mod platform;
 
-extern crate boxfnonce;
 extern crate libc;
 #[macro_use]
 extern crate log;

--- a/src/linux/transaction.rs
+++ b/src/linux/transaction.rs
@@ -5,7 +5,7 @@
 use platform::monitor::Monitor;
 use runloop::RunLoop;
 use std::ffi::OsString;
-use util::OnceCallback;
+use util::StateCallback;
 
 pub struct Transaction {
     // Handle to the thread loop.
@@ -15,7 +15,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/macos/transaction.rs
+++ b/src/macos/transaction.rs
@@ -24,7 +24,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: StateCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/macos/transaction.rs
+++ b/src/macos/transaction.rs
@@ -10,7 +10,7 @@ use platform::monitor::Monitor;
 use std::os::raw::c_void;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
-use util::OnceCallback;
+use util::StateCallback;
 
 // A transaction will run the given closure in a new thread, thereby using a
 // separate per-thread state machine for each HID. It will either complete or
@@ -24,7 +24,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<T>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -18,7 +18,7 @@ enum QueueAction {
         challenge: Vec<u8>,
         application: ::AppId,
         key_handles: Vec<::KeyHandle>,
-        callback: StateCallback<::RegisterResult>,
+        callback: StateCallback<Result<::RegisterResult, ::Error>>,
     },
     Sign {
         flags: ::SignFlags,
@@ -26,7 +26,7 @@ enum QueueAction {
         challenge: Vec<u8>,
         app_ids: Vec<::AppId>,
         key_handles: Vec<::KeyHandle>,
-        callback: StateCallback<::SignResult>,
+        callback: StateCallback<Result<::SignResult, ::Error>>,
     },
     Cancel,
 }

--- a/src/netbsd/transaction.rs
+++ b/src/netbsd/transaction.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use runloop::RunLoop;
-use util::OnceCallback;
+use util::StateCallback;
 
 use platform::fd::Fd;
 use platform::monitor::Monitor;
@@ -16,7 +16,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/openbsd/transaction.rs
+++ b/src/openbsd/transaction.rs
@@ -4,7 +4,7 @@
 
 use platform::monitor::{FidoDev, Monitor};
 use runloop::RunLoop;
-use util::OnceCallback;
+use util::StateCallback;
 
 pub struct Transaction {
     // Handle to the thread loop.
@@ -14,7 +14,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -56,7 +56,7 @@ impl StateMachine {
         challenge: Vec<u8>,
         application: ::AppId,
         key_handles: Vec<::KeyHandle>,
-        callback: StateCallback<::RegisterResult>,
+        callback: StateCallback<Result<::RegisterResult, ::Error>>,
     ) {
         // Abort any prior register/sign calls.
         self.cancel();
@@ -122,7 +122,7 @@ impl StateMachine {
         challenge: Vec<u8>,
         app_ids: Vec<::AppId>,
         key_handles: Vec<::KeyHandle>,
-        callback: StateCallback<::SignResult>,
+        callback: StateCallback<Result<::SignResult, ::Error>>,
     ) {
         // Abort any prior register/sign calls.
         self.cancel();

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -8,7 +8,7 @@ use platform::transaction::Transaction;
 use std::thread;
 use std::time::Duration;
 use u2fprotocol::{u2f_init_device, u2f_is_keyhandle_valid, u2f_register, u2f_sign};
-use util::OnceCallback;
+use util::StateCallback;
 
 fn is_valid_transport(transports: ::AuthenticatorTransports) -> bool {
     transports.is_empty() || transports.contains(::AuthenticatorTransports::USB)
@@ -56,7 +56,7 @@ impl StateMachine {
         challenge: Vec<u8>,
         application: ::AppId,
         key_handles: Vec<::KeyHandle>,
-        callback: OnceCallback<::RegisterResult>,
+        callback: StateCallback<::RegisterResult>,
     ) {
         // Abort any prior register/sign calls.
         self.cancel();
@@ -122,7 +122,7 @@ impl StateMachine {
         challenge: Vec<u8>,
         app_ids: Vec<::AppId>,
         key_handles: Vec<::KeyHandle>,
-        callback: OnceCallback<::SignResult>,
+        callback: StateCallback<::SignResult>,
     ) {
         // Abort any prior register/sign calls.
         self.cancel();

--- a/src/stub/transaction.rs
+++ b/src/stub/transaction.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use util::OnceCallback;
+use util::StateCallback;
 
 pub struct Transaction {}
 
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,7 +72,7 @@ pub struct StateCallback<T> {
 }
 
 impl<T> StateCallback<T> {
-    pub fn new(cb: Box<dyn Fn(T) + Send + 'static>) -> Self {
+    pub fn new(cb: Box<dyn Fn(T) + Send>) -> Self {
         Self {
             callback: Arc::new(Mutex::new(Some(cb))),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -68,18 +68,17 @@ pub fn io_err(msg: &str) -> io::Error {
 }
 
 pub struct StateCallback<T> {
-    callback: Arc<Mutex<Option<Box<dyn Fn(Result<T, ::Error>,) + Send>>>>,
+    callback: Arc<Mutex<Option<Box<dyn Fn(T) + Send>>>>,
 }
 
 impl<T> StateCallback<T> {
-    pub fn new(cb: Box<dyn Fn(Result<T, ::Error>) + Send + 'static>) -> Self
-    {
+    pub fn new(cb: Box<dyn Fn(T) + Send + 'static>) -> Self {
         Self {
             callback: Arc::new(Mutex::new(Some(cb))),
         }
     }
 
-    pub fn call(&self, rv: Result<T, ::Error>) {
+    pub fn call(&self, rv: T) {
         if let Ok(mut cb) = self.callback.lock() {
             if let Some(cb) = cb.take() {
                 cb(rv);

--- a/src/windows/transaction.rs
+++ b/src/windows/transaction.rs
@@ -4,7 +4,7 @@
 
 use platform::monitor::Monitor;
 use runloop::RunLoop;
-use util::OnceCallback;
+use util::StateCallback;
 
 pub struct Transaction {
     // Handle to the thread loop.
@@ -14,7 +14,7 @@ pub struct Transaction {
 impl Transaction {
     pub fn new<F, T>(
         timeout: u64,
-        callback: OnceCallback<T>,
+        callback: StateCallback<Result<T, ::Error>>,
         new_device_cb: F,
     ) -> Result<Self, ::Error>
     where


### PR DESCRIPTION
Since we're now not limited to `FnOnce` trait, this is useful for status callbacks as well, so I generalize it to an `Fn` trait of generic argument in advance of upstream status reporting.