### PR TITLE
Rust 1.46 clippy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
     echo "Running rustfmt"
     cargo fmt --all -- --check
     echo "Running clippy"
-    cargo clippy --all-targets -- -A renamed_and_removed_lints -A clippy::new-ret-no-self -D warnings
+    cargo clippy --all-targets --all-features -- -A renamed_and_removed_lints -A clippy::new-ret-no-self -D warnings
 
     rustup install nightly
     cargo install cargo-fuzz
     cargo +nightly fuzz build
   fi
-- cargo test --all-targets
+- cargo test --all-targets --all-features

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -544,7 +544,7 @@ mod tests {
                 mk_challenge(),
                 mk_appid(),
                 vec![],
-                status_tx.clone(),
+                status_tx,
                 callback.clone(),
             )
             .is_ok());
@@ -616,7 +616,7 @@ mod tests {
                 mk_challenge(),
                 mk_appid(),
                 vec![],
-                status_tx.clone(),
+                status_tx,
                 callback.clone(),
             )
             .is_ok());

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -136,7 +136,7 @@ impl AuthenticatorService {
             );
 
             transport_mutex.lock().unwrap().register(
-                flags.clone(),
+                flags,
                 timeout,
                 challenge.clone(),
                 application.clone(),
@@ -189,7 +189,7 @@ impl AuthenticatorService {
             transports_to_cancel.remove(idx);
 
             transport_mutex.lock().unwrap().sign(
-                flags.clone(),
+                flags,
                 timeout,
                 challenge.clone(),
                 app_ids.clone(),

--- a/src/linux/monitor.rs
+++ b/src/linux/monitor.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use libc::{c_int, c_short, c_ulong};
-use libudev;
 use libudev::EventType;
 use runloop::RunLoop;
 use std::collections::HashMap;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -140,9 +140,7 @@ impl AuthenticatorTransport for U2FManager {
             status,
             callback,
         };
-        self.tx
-            .send(action)
-            .map_err(|e| AuthenticatorError::from(e))
+        self.tx.send(action).map_err(AuthenticatorError::from)
     }
 
     fn sign(

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -140,7 +140,7 @@ impl AuthenticatorTransport for U2FManager {
             status,
             callback,
         };
-        self.tx.send(action).map_err(AuthenticatorError::from)
+        Ok(self.tx.send(action)?)
     }
 
     fn sign(

--- a/src/statecallback.rs
+++ b/src/statecallback.rs
@@ -11,6 +11,8 @@ pub struct StateCallback<T> {
 }
 
 impl<T> StateCallback<T> {
+    // This is used for the Condvar, which requires this kind of construction
+    #[allow(clippy::mutex_atomic)]
     pub fn new(cb: Box<dyn Fn(T) + Send>) -> Self {
         Self {
             callback: Arc::new(Mutex::new(Some(cb))),
@@ -139,6 +141,8 @@ mod tests {
         sc.add_uncloneable_observer(Box::new(move || {}));
 
         assert!(sc.observer.lock().unwrap().is_some());
+        // This is deliberate, to force an extra clone
+        #[allow(clippy::redundant_clone)]
         assert!(sc.clone().observer.lock().unwrap().is_none());
     }
 

--- a/src/statecallback.rs
+++ b/src/statecallback.rs
@@ -136,13 +136,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn test_statecallback_observer_unclonable() {
         let mut sc = StateCallback::<()>::new(Box::new(move |_| {}));
         sc.add_uncloneable_observer(Box::new(move || {}));
 
         assert!(sc.observer.lock().unwrap().is_some());
         // This is deliberate, to force an extra clone
-        #[allow(clippy::redundant_clone)]
         assert!(sc.clone().observer.lock().unwrap().is_none());
     }
 

--- a/src/virtualdevices/webdriver/testtoken.rs
+++ b/src/virtualdevices/webdriver/testtoken.rs
@@ -52,19 +52,17 @@ impl TestToken {
         has_resident_key: bool,
     ) -> TestToken {
         match protocol {
-            TestWireProtocol::CTAP1 => {
-                return Self {
-                    id,
-                    protocol,
-                    transport,
-                    is_user_consenting,
-                    has_user_verification,
-                    is_user_verified,
-                    has_resident_key,
-                    u2f_impl: Some(SoftwareU2FToken::new()),
-                    credentials: Vec::new(),
-                }
-            }
+            TestWireProtocol::CTAP1 => Self {
+                id,
+                protocol,
+                transport,
+                is_user_consenting,
+                has_user_verification,
+                is_user_verified,
+                has_resident_key,
+                u2f_impl: Some(SoftwareU2FToken::new()),
+                credentials: Vec::new(),
+            },
             _ => unreachable!(),
         }
     }
@@ -91,7 +89,7 @@ impl TestToken {
             .credentials
             .binary_search_by_key(&credential, |probe| &probe.credential)
         {
-            Ok(_) => return,
+            Ok(_) => {}
             Err(idx) => self.credentials.insert(idx, c),
         }
     }

--- a/src/virtualdevices/webdriver/virtualmanager.rs
+++ b/src/virtualdevices/webdriver/virtualmanager.rs
@@ -43,7 +43,7 @@ impl VirtualManager {
 
         let builder = thread::Builder::new().name("WebDriver Command Server".into());
         builder.spawn(move || {
-            web_api::serve(stateclone, addr.clone());
+            web_api::serve(stateclone, addr);
         })?;
 
         Ok(Self {

--- a/src/virtualdevices/webdriver/web_api.rs
+++ b/src/virtualdevices/webdriver/web_api.rs
@@ -596,8 +596,8 @@ mod tests {
     }
 
     fn assert_creds_equals_test_token_params(
-        a: &Vec<CredentialParameters>,
-        b: &Vec<TestTokenCredential>,
+        a: &[CredentialParameters],
+        b: &[TestTokenCredential],
     ) {
         assert_eq!(a.len(), b.len());
 

--- a/src/virtualdevices/webdriver/web_api.rs
+++ b/src/virtualdevices/webdriver/web_api.rs
@@ -248,14 +248,12 @@ mod handlers {
                 && uri.path_and_query().is_none()
                 && uri.port().is_none()
                 && uri.host().is_some()
+                && uri.authority().unwrap() == uri.host().unwrap()
+                // Don't try too hard to ensure it's a valid domain, just
+                // ensure there's a label delim in there somewhere
+                && uri.host().unwrap().find('.').is_some()
             {
-                if uri.authority().unwrap() == uri.host().unwrap() {
-                    // Don't try too hard to ensure it's a valid domain, just
-                    // ensure there's a label delim in there somewhere
-                    if uri.host().unwrap().find('.').is_some() {
-                        return Ok(());
-                    }
-                }
+                return Ok(());
             }
         }
         Err(crate::errors::AuthenticatorError::U2FToken(

--- a/src/virtualdevices/webdriver/web_api.rs
+++ b/src/virtualdevices/webdriver/web_api.rs
@@ -512,7 +512,6 @@ mod tests {
     use super::*;
     use crate::virtualdevices::webdriver::virtualmanager::VirtualManagerState;
     use bytes::Buf;
-    use serde_json;
     use std::sync::{Arc, Mutex};
     use warp::http::StatusCode;
 


### PR DESCRIPTION
Clippy issues which have appeared since moving from Rust 1.43 to Rust 1.46.