### PR TITLE
Ensure OpenBSD has `use std::io`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authenticator"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>", "Kyle Machulis <kyle@nonpolynomial.com>"]
 keywords = ["ctap2", "u2f", "fido", "webauthn"]
 categories = ["cryptography", "hardware-support", "os"]

--- a/src/openbsd/device.rs
+++ b/src/openbsd/device.rs
@@ -5,6 +5,7 @@
 extern crate libc;
 
 use std::ffi::OsString;
+use std::io;
 use std::io::{Read, Result, Write};
 use std::mem;
 


### PR DESCRIPTION
Fix #139 and https://bugzilla.mozilla.org/show_bug.cgi?id=1666701

I'm still upgrading to OpenBSD 6.7 locally so I can use the necessary version of Rust, but I think this is all that's needed. This and a version bump.