### PR TITLE
Fix panic msg is not a string literal warning

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -53,7 +53,7 @@ fn main() {
     opts.optflag("h", "help", "print this help menu");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => panic!(f.to_string()),
+        Err(f) => panic!("{}", f.to_string()),
     };
     if matches.opt_present("help") {
         print_usage(&program, opts);


### PR DESCRIPTION
Fixes the non_fmt_panic warning.