### PR TITLE
Update application-services dependency to v84.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,9 @@ cfg-if = "1.0"
 ring = { version = "0.16", optional = true }
 openssl-sys = { version = "0.9", optional = true}
 openssl = { version = "0.10", optional = true}
-rc_crypto = { git = "https://github.com/mozilla/application-services", rev="8a576fbe79199fa8664f64285524017f74ebcc5f", optional = true, feature="gecko"}
-nss = { git = "https://github.com/mozilla/application-services", rev="8a576fbe79199fa8664f64285524017f74ebcc5f", optional = true, feature="gecko"}
-nss_sys = { git = "https://github.com/mozilla/application-services", rev="8a576fbe79199fa8664f64285524017f74ebcc5f", optional = true, feature="gecko"}
+rc_crypto = { git = "https://github.com/mozilla/application-services", rev="c51b63595a27a6ef45161012323e0261475c10c9", optional = true, feature="gecko"}
+nss = { git = "https://github.com/mozilla/application-services", rev="c51b63595a27a6ef45161012323e0261475c10c9", optional = true, feature="gecko"}
+nss_sys = { git = "https://github.com/mozilla/application-services", rev="c51b63595a27a6ef45161012323e0261475c10c9", optional = true, feature="gecko"}
 
 [dev-dependencies]
 base64 = "^0.10"


### PR DESCRIPTION
Same as is vendored in mozilla-central, so that we can use this repo for vendoring.
The already vendored packages where updated while this branch was in review.