### PR TITLE
Address `warning: panic message is not a string literal`

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -53,7 +53,7 @@ fn main() {
     opts.optflag("h", "help", "print this help menu");
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => panic!(f.to_string()),
+        Err(f) => panic!("{}", f),
     };
     if matches.opt_present("help") {
         print_usage(&program, opts);


### PR DESCRIPTION
When running:

    cargo build --example main

we receive the following warning:

```
warning: panic message is not a string literal
  --> examples/main.rs:56:26
   |
56 |         Err(f) => panic!(f.to_string()),
   |                          ^^^^^^^^^^^^^
   |
   = note: `#[warn(non_fmt_panics)]` on by default
   = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
help: add a "{}" format string to Display the message
   |
56 |         Err(f) => panic!("{}", f.to_string()),
   |                          +++++

warning: `authenticator` (example "main") generated 1 warning
```

This commit puts in place the suggested fix, and removes the
explicit call to `to_string()`