### PR TITLE
Update warp and tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ log = "0.4"
 libc = "0.2"
 runloop = "0.1.0"
 bitflags = "1.0"
-tokio = { version = "0.2", optional = true, features = ["macros"] }
-warp = { version = "0.2.4", optional = true }
+tokio = { version = "1.0", optional = true, features = ["macros", "rt-multi-thread"] }
+warp = { version = "0.3.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 bytes = { version = "0.5", optional = true, features = ["serde"] }

--- a/src/virtualdevices/webdriver/web_api.rs
+++ b/src/virtualdevices/webdriver/web_api.rs
@@ -511,7 +511,6 @@ mod tests {
     use super::testtoken::*;
     use super::*;
     use crate::virtualdevices::webdriver::virtualmanager::VirtualManagerState;
-    use bytes::Buf;
     use std::sync::{Arc, Mutex};
     use warp::http::StatusCode;
 
@@ -591,8 +590,8 @@ mod tests {
         state
     }
 
-    fn assert_success_rsp_blank(body: &bytes::Bytes) {
-        assert_eq!(String::from_utf8_lossy(body.bytes()), r#"{}"#)
+    fn assert_success_rsp_blank(body: &warp::hyper::body::Bytes) {
+        assert_eq!(String::from_utf8_lossy(&body), r#"{}"#)
     }
 
     fn assert_creds_equals_test_token_params(
@@ -653,7 +652,7 @@ mod tests {
                 .reply(&filter)
                 .await;
             assert!(res.status().is_client_error());
-            assert!(String::from_utf8_lossy(res.body().bytes())
+            assert!(String::from_utf8_lossy(&res.body())
                 .contains(&String::from("unknown protocol: unknown")));
         }
 
@@ -668,7 +667,7 @@ mod tests {
                 .await;
             assert!(res.status().is_success());
             assert_eq!(
-                String::from_utf8_lossy(res.body().bytes()),
+                String::from_utf8_lossy(&res.body()),
                 r#"{"authenticatorId":1}"#
             )
         }
@@ -682,7 +681,7 @@ mod tests {
                 .await;
             assert!(res.status().is_success());
             assert_eq!(
-                String::from_utf8_lossy(res.body().bytes()),
+                String::from_utf8_lossy(&res.body()),
                 r#"{"authenticatorId":2}"#
             )
         }


### PR DESCRIPTION
This updates warp to 0.3.2 and tokio to 1.0. These libraries are only used for
testing. This update should help prevent duplicated copies of tokio when
vendoring into mozilla-central.