### PR TITLE
Adjust unsafe blocks for the DeviceCapabilities impl

### DIFF
--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -250,18 +250,18 @@ impl DeviceCapabilities {
         }
 
         let mut caps = mem::MaybeUninit::<hidpi::HIDP_CAPS>::uninit();
-        unsafe {
-            let rv = HidP_GetCaps(preparsed_data, caps.as_mut_ptr());
-            HidD_FreePreparsedData(preparsed_data);
+        
+            let rv = unsafe { HidP_GetCaps(preparsed_data, caps.as_mut_ptr()) };
+            unsafe { HidD_FreePreparsedData(preparsed_data) };
 
             if rv != hidpi::HIDP_STATUS_SUCCESS {
                 return Err(io_err("HidP_GetCaps failed!"));
             }
 
             Ok(Self {
-                caps: caps.assume_init(),
+                caps: unsafe { caps.assume_init() },
             })
-        }
+        
     }
 
     pub fn usage(&self) -> hidusage::USAGE {


### PR DESCRIPTION
In this function you use the unsafe keyword for many safe expressions. However, I found that only 3 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the HidP_GetCaps()/HidD_FreePreparsedData()/assume_init() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 