### PR TITLE
Do not error out if the token returns options unknown to us

### DIFF
--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -230,7 +230,10 @@ impl<'de> Deserialize<'de> for AuthenticatorInfo {
                             }
                             algorithms = Some(map.next_value()?);
                         }
-                        k => return Err(M::Error::custom(format!("unexpected key: {:?}", k))),
+                        k => {
+                            warn!("GetInfo: unexpected key: {:?}", k);
+                            continue;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This might happen, if the token is very new and supports a newer CTAP-specification.
In that case, we simply don't support it, but shouldn't error out.