### PR TITLE
Use memoffset instead of homebrew offset_of

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ devd-rs = "0.3"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+memoffset = "0.6"
+
 [target.'cfg(target_os = "windows")'.dependencies.winapi]
 version = "^0.3"
 features = [

--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -63,12 +63,6 @@ extern "system" {
     ) -> ntdef::NTSTATUS;
 }
 
-macro_rules! offset_of {
-    ($ty:ty, $field:ident) => {
-        unsafe { &(*(0 as *const $ty)).$field as *const _ as usize }
-    };
-}
-
 fn from_wide_ptr(ptr: *const u16, len: usize) -> String {
     assert!(!ptr.is_null() && len % 2 == 0);
     let slice = unsafe { slice::from_raw_parts(ptr, len / 2) };
@@ -214,7 +208,7 @@ impl DeviceInterfaceDetailData {
         unsafe { (*data).cbSize = cb_size as minwindef::UINT };
 
         // Compute offset of `SP_DEVICE_INTERFACE_DETAIL_DATA_W.DevicePath`.
-        let offset = offset_of!(setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
+        let offset = memoffset::offset_of!(setupapi::SP_DEVICE_INTERFACE_DETAIL_DATA_W, DevicePath);
 
         Some(Self {
             data,


### PR DESCRIPTION
This was generating warnings/errors because the homebrew macro dereferences a null pointer and produces a reference to an unaligned field.

memoffset's implementation does this in a way that doesn't rely on UB (when building with rust >=1.51).