### PR TITLE
Remove unneeded explicit close-call, since the file will be close automatically

### DIFF
--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -28,13 +28,6 @@ pub struct Device {
     authenticator_info: Option<AuthenticatorInfo>,
 }
 
-impl Drop for Device {
-    fn drop(&mut self) {
-        // Close the fd, ignore any errors.
-        let _ = unsafe { libc::close(self.fd.as_raw_fd()) };
-    }
-}
-
 impl PartialEq for Device {
     fn eq(&self, other: &Device) -> bool {
         // The path should be the only identifying member for a device


### PR DESCRIPTION
This is a forgotten leftover when switching to storing `File`s directly instead of file-handles. This is not needed at all.