### PR TITLE
Relax keylength checks for CTAP2 and implement excludeList-support for CTAP1

### DIFF
--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use authenticator::{
+    authenticatorservice::{
+        AuthenticatorService, CtapVersion, MakeCredentialsOptions, RegisterArgsCtap2,
+    },
+    ctap2::commands::StatusCode,
+    ctap2::server::{
+        PublicKeyCredentialDescriptor, PublicKeyCredentialParameters, RelyingParty, Transport, User,
+    },
+    errors::{AuthenticatorError, CommandError, HIDError, PinError},
+    statecallback::StateCallback,
+    COSEAlgorithm, Pin, RegisterResult, StatusUpdate,
+};
+
+use getopts::Options;
+use sha2::{Digest, Sha256};
+use std::sync::mpsc::{channel, RecvError};
+use std::{env, thread};
+
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {} [options]", program);
+    print!("{}", opts.usage(&brief));
+}
+
+fn main() {
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "print this help menu").optopt(
+        "t",
+        "timeout",
+        "timeout in seconds",
+        "SEC",
+    );
+    opts.optflag("h", "help", "print this help menu");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!("{}", f.to_string()),
+    };
+    if matches.opt_present("help") {
+        print_usage(&program, opts);
+        return;
+    }
+
+    let mut manager = AuthenticatorService::new(CtapVersion::CTAP2)
+        .expect("The auth service should initialize safely");
+
+    manager.add_u2f_usb_hid_platform_transports();
+
+    let timeout_ms = match matches.opt_get_default::<u64>("timeout", 25) {
+        Ok(timeout_s) => {
+            println!("Using {}s as the timeout", &timeout_s);
+            timeout_s * 1_000
+        }
+        Err(e) => {
+            println!("{}", e);
+            print_usage(&program, opts);
+            return;
+        }
+    };
+
+    println!("Asking a security key to register now...");
+    let challenge_str = format!(
+        "{}{}",
+        r#"{"challenge": "1vQ9mxionq0ngCnjD-wTsv1zUSrGRtFqG2xP09SbZ70","#,
+        r#" "version": "U2F_V2", "appId": "http://example.com"}"#
+    );
+    let mut challenge = Sha256::new();
+    challenge.update(challenge_str.as_bytes());
+    let chall_bytes = challenge.finalize().to_vec();
+
+    // TODO(MS): Needs to be added to RegisterArgsCtap2
+    // let flags = RegisterFlags::empty();
+
+    let (status_tx, status_rx) = channel::<StatusUpdate>();
+    thread::spawn(move || loop {
+        match status_rx.recv() {
+            Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
+                println!("STATUS: device available: {}", dev_info)
+            }
+            Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
+                println!("STATUS: device unavailable: {}", dev_info)
+            }
+            Ok(StatusUpdate::Success { dev_info }) => {
+                println!("STATUS: success using device: {}", dev_info);
+            }
+            Ok(StatusUpdate::SelectDeviceNotice) => {
+                println!("STATUS: Please select a device by touching one of them.");
+            }
+            Ok(StatusUpdate::DeviceSelected(dev_info)) => {
+                println!("STATUS: Continuing with device: {}", dev_info);
+            }
+            Ok(StatusUpdate::PinError(error, sender)) => match error {
+                PinError::PinRequired => {
+                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
+                        .expect("Failed to read PIN");
+                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
+                    continue;
+                }
+                PinError::InvalidPin(attempts) => {
+                    println!(
+                        "Wrong PIN! {}",
+                        attempts.map_or(format!("Try again."), |a| format!(
+                            "You have {} attempts left.",
+                            a
+                        ))
+                    );
+                    let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
+                        .expect("Failed to read PIN");
+                    sender.send(Pin::new(&raw_pin)).expect("Failed to send PIN");
+                    continue;
+                }
+                PinError::PinAuthBlocked => {
+                    panic!("Too many failed attempts in one row. Your device has been temporarily blocked. Please unplug it and plug in again.")
+                }
+                PinError::PinBlocked => {
+                    panic!("Too many failed attempts. Your device has been blocked. Reset it.")
+                }
+                e => {
+                    panic!("Unexpected error: {:?}", e)
+                }
+            },
+            Err(RecvError) => {
+                println!("STATUS: end");
+                return;
+            }
+        }
+    });
+
+    let user = User {
+        id: "user_id".as_bytes().to_vec(),
+        icon: None,
+        name: Some("A. User".to_string()),
+        display_name: None,
+    };
+    let origin = "https://example.com".to_string();
+    let mut ctap_args = RegisterArgsCtap2 {
+        challenge: chall_bytes.clone(),
+        relying_party: RelyingParty {
+            id: "example.com".to_string(),
+            name: None,
+            icon: None,
+        },
+        origin: origin.clone(),
+        user: user.clone(),
+        pub_cred_params: vec![
+            PublicKeyCredentialParameters {
+                alg: COSEAlgorithm::ES256,
+            },
+            PublicKeyCredentialParameters {
+                alg: COSEAlgorithm::RS256,
+            },
+        ],
+        exclude_list: vec![],
+        options: MakeCredentialsOptions {
+            resident_key: None,
+            user_verification: None,
+        },
+        extensions: Default::default(),
+        pin: None,
+    };
+
+    loop {
+        let (register_tx, register_rx) = channel();
+        let callback = StateCallback::new(Box::new(move |rv| {
+            register_tx.send(rv).unwrap();
+        }));
+
+        if let Err(e) = manager.register(
+            timeout_ms,
+            ctap_args.clone().into(),
+            status_tx.clone(),
+            callback,
+        ) {
+            panic!("Couldn't register: {:?}", e);
+        };
+
+        let register_result = register_rx
+            .recv()
+            .expect("Problem receiving, unable to continue");
+        match register_result {
+            Ok(RegisterResult::CTAP1(_, _)) => panic!("Requested CTAP2, but got CTAP1 results!"),
+            Ok(RegisterResult::CTAP2(a, _c)) => {
+                println!("Ok!");
+                println!("Registering again with the key_handle we just got back. This should result in a 'already registered' error.");
+                let registered_key_handle =
+                    a.auth_data.credential_data.unwrap().credential_id.clone();
+                ctap_args.exclude_list = vec![PublicKeyCredentialDescriptor {
+                    id: registered_key_handle.clone(),
+                    transports: vec![Transport::USB],
+                }];
+                continue;
+            }
+            Err(AuthenticatorError::HIDError(HIDError::Command(CommandError::StatusCode(
+                StatusCode::CredentialExcluded,
+                None,
+            )))) => {
+                println!("Got an 'already registered' error. Quitting.");
+                break;
+            }
+            Err(e) => panic!("Registration failed: {:?}", e),
+        };
+    }
+    println!("Done")
+}

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -366,6 +366,10 @@ impl RequestCtap1 for GetAssertion {
         let key_handle = self
             .allow_list
             .iter()
+            // key-handles in CTAP1 are limited to 255 bytes, but are not limited in CTAP2.
+            // Filter out key-handles that are too long (can happen if this is a CTAP2-request,
+            // but the token only speaks CTAP1). If none is found, return an error.
+            .filter(|allowed_handle| allowed_handle.id.len() < 256)
             .find_map(|allowed_handle| {
                 let check_command = GetAssertionCheck {
                     key_handle: allowed_handle.id.as_ref(),
@@ -658,7 +662,7 @@ impl<'de> Deserialize<'de> for GetAssertionResponse {
 
 #[cfg(test)]
 pub mod test {
-    use super::{Assertion, GetAssertion, GetAssertionOptions, GetAssertionResult};
+    use super::{Assertion, GetAssertion, GetAssertionOptions, GetAssertionResult, HIDError};
     use crate::consts::{
         HIDCmd, SW_CONDITIONS_NOT_SATISFIED, SW_NO_ERROR, U2F_CHECK_IS_REGISTERED,
         U2F_REQUEST_USER_PRESENCE,
@@ -918,7 +922,7 @@ pub mod test {
 
         device.set_cid(cid);
 
-        // ctap2 request
+        // ctap1 request
         fill_device_ctap1(
             &mut device,
             cid,
@@ -926,6 +930,122 @@ pub mod test {
             SW_CONDITIONS_NOT_SATISFIED,
         );
         let ctap1_request = assertion.apdu_format(&mut device).unwrap();
+        // Check if the request is going to be correct
+        assert_eq!(ctap1_request, GET_ASSERTION_SAMPLE_REQUEST_CTAP1);
+
+        // Now do it again, but parse the actual response
+        fill_device_ctap1(
+            &mut device,
+            cid,
+            U2F_CHECK_IS_REGISTERED,
+            SW_CONDITIONS_NOT_SATISFIED,
+        );
+        fill_device_ctap1(&mut device, cid, U2F_REQUEST_USER_PRESENCE, SW_NO_ERROR);
+
+        let response = device.send_apdu(&assertion).unwrap();
+
+        // Check if response is correct
+        let expected_auth_data = AuthenticatorData {
+            rp_id_hash: RpIdHash(RELYING_PARTY_HASH),
+            flags: AuthenticatorDataFlags::USER_PRESENT,
+            counter: 0x3B,
+            credential_data: None,
+            extensions: Default::default(),
+        };
+
+        let expected_assertion = Assertion {
+            credentials: None,
+            signature: vec![
+                0x30, 0x44, 0x02, 0x20, 0x7B, 0xDE, 0x0A, 0x52, 0xAC, 0x1F, 0x4C, 0x8B, 0x27, 0xE0,
+                0x03, 0xA3, 0x70, 0xCD, 0x66, 0xA4, 0xC7, 0x11, 0x8D, 0xD2, 0x2D, 0x54, 0x47, 0x83,
+                0x5F, 0x45, 0xB9, 0x9C, 0x68, 0x42, 0x3F, 0xF7, 0x02, 0x20, 0x3C, 0x51, 0x7B, 0x47,
+                0x87, 0x7F, 0x85, 0x78, 0x2D, 0xE1, 0x00, 0x86, 0xA7, 0x83, 0xD1, 0xE7, 0xDF, 0x4E,
+                0x36, 0x39, 0xE7, 0x71, 0xF5, 0xF6, 0xAF, 0xA3, 0x5A, 0xAD, 0x53, 0x73, 0x85, 0x8E,
+            ],
+            user: None,
+            auth_data: expected_auth_data,
+        };
+
+        let expected =
+            GetAssertionResult::CTAP2(AssertionObject(vec![expected_assertion]), client_data);
+
+        assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn test_get_assertion_ctap1_long_keys() {
+        let client_data = CollectedClientData {
+            webauthn_type: WebauthnType::Create,
+            challenge: Challenge::from(vec![0x00, 0x01, 0x02, 0x03]),
+            origin: String::from("example.com"),
+            cross_origin: false,
+            token_binding: Some(TokenBinding::Present(String::from("AAECAw"))),
+        };
+
+        let too_long_key_handle = PublicKeyCredentialDescriptor {
+            id: vec![0; 1000],
+            transports: vec![Transport::USB],
+        };
+        let mut assertion = GetAssertion::new(
+            client_data.clone(),
+            RelyingPartyWrapper::Data(RelyingParty {
+                id: String::from("example.com"),
+                name: Some(String::from("Acme")),
+                icon: None,
+            }),
+            vec![too_long_key_handle.clone()],
+            GetAssertionOptions {
+                user_presence: Some(true),
+                user_verification: None,
+            },
+            Default::default(),
+            None,
+        );
+        let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
+                                                                         // channel id
+        let mut cid = [0u8; 4];
+        thread_rng().fill_bytes(&mut cid);
+
+        device.set_cid(cid);
+
+        assert_matches!(
+            assertion.apdu_format(&mut device),
+            Err(HIDError::DeviceNotSupported)
+        );
+
+        assertion.allow_list = vec![too_long_key_handle.clone(); 5];
+
+        assert_matches!(
+            assertion.apdu_format(&mut device),
+            Err(HIDError::DeviceNotSupported)
+        );
+        let ok_key_handle = PublicKeyCredentialDescriptor {
+            id: vec![
+                0x3E, 0xBD, 0x89, 0xBF, 0x77, 0xEC, 0x50, 0x97, 0x55, 0xEE, 0x9C, 0x26, 0x35, 0xEF,
+                0xAA, 0xAC, 0x7B, 0x2B, 0x9C, 0x5C, 0xEF, 0x17, 0x36, 0xC3, 0x71, 0x7D, 0xA4, 0x85,
+                0x34, 0xC8, 0xC6, 0xB6, 0x54, 0xD7, 0xFF, 0x94, 0x5F, 0x50, 0xB5, 0xCC, 0x4E, 0x78,
+                0x05, 0x5B, 0xDD, 0x39, 0x6B, 0x64, 0xF7, 0x8D, 0xA2, 0xC5, 0xF9, 0x62, 0x00, 0xCC,
+                0xD4, 0x15, 0xCD, 0x08, 0xFE, 0x42, 0x00, 0x38,
+            ],
+            transports: vec![Transport::USB],
+        };
+        assertion.allow_list = vec![
+            too_long_key_handle.clone(),
+            too_long_key_handle.clone(),
+            too_long_key_handle.clone(),
+            ok_key_handle,
+            too_long_key_handle.clone(),
+        ];
+
+        // ctap1 request
+        fill_device_ctap1(
+            &mut device,
+            cid,
+            U2F_CHECK_IS_REGISTERED,
+            SW_CONDITIONS_NOT_SATISFIED,
+        );
+        let ctap1_request = assertion.apdu_format(&mut device).unwrap();
+
         // Check if the request is going to be correct
         assert_eq!(ctap1_request, GET_ASSERTION_SAMPLE_REQUEST_CTAP1);
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -418,7 +418,10 @@ impl AuthenticatorTransport for Manager {
                     vec![PublicKeyCredentialParameters {
                         alg: COSEAlgorithm::ES256,
                     }],
-                    vec![], // TODO(MS): Implement excludeList. See spec.
+                    args.key_handles
+                        .iter()
+                        .map(|k| k.into())
+                        .collect::<Vec<_>>(),
                     MakeCredentialsOptions {
                         resident_key: None,
                         user_verification: None,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -166,7 +166,7 @@ impl AuthenticatorTransport for U2FManager {
         }
 
         for key_handle in &args.key_handles {
-            if key_handle.credential.len() > 256 {
+            if key_handle.credential.len() >= 256 {
                 return Err(AuthenticatorError::InvalidRelyingPartyInput);
             }
         }
@@ -209,7 +209,7 @@ impl AuthenticatorTransport for U2FManager {
         }
 
         for key_handle in &args.key_handles {
-            if key_handle.credential.len() > 256 {
+            if key_handle.credential.len() >= 256 {
                 return Err(AuthenticatorError::InvalidRelyingPartyInput);
             }
         }
@@ -478,7 +478,7 @@ impl AuthenticatorTransport for Manager {
                         return Err(AuthenticatorError::InvalidRelyingPartyInput);
                     }
                     for key_handle in &args.key_handles {
-                        if key_handle.credential.len() > 256 {
+                        if key_handle.credential.len() >= 256 {
                             return Err(AuthenticatorError::InvalidRelyingPartyInput);
                         }
                         let rp = RelyingPartyWrapper::Hash(RpIdHash::from(&app_id)?);


### PR DESCRIPTION
Looks bigger than it is. Mostly refactoring out some longer things to reuse them, and adding a new test-binary to check the excludeList-feature. 