### PR TITLE
Rename and document `U2FAPDUHeader` and fix Nc=0 (ctap2-2021 branch)

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,7 +8,15 @@
 use serde::Serialize;
 
 pub const MAX_HID_RPT_SIZE: usize = 64;
+
+/// Minimum size of the U2F Raw Message header (FIDO v1.x) in extended mode,
+/// including expected response length (L<sub>e</sub>).
+///
+/// Fields `CLA`, `INS`, `P1` and `P2` are 1 byte each, and L<sub>e</sub> is 3
+/// bytes. If there is a data payload, add 2 bytes (L<sub>c</sub> is 3 bytes,
+/// and L<sub>e</sub> is 2 bytes).
 pub const U2FAPDUHEADER_SIZE: usize = 7;
+
 pub const CID_BROADCAST: [u8; 4] = [0xff, 0xff, 0xff, 0xff];
 pub const TYPE_MASK: u8 = 0x80;
 pub const TYPE_INIT: u8 = 0x80;

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -15,7 +15,7 @@ use crate::ctap2::server::{PublicKeyCredentialDescriptor, RelyingPartyWrapper, U
 use crate::errors::AuthenticatorError;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
 use crate::transport::FidoDevice;
-use crate::u2ftypes::{U2FAPDUHeader, U2FDevice};
+use crate::u2ftypes::{CTAP1RequestAPDU, U2FDevice};
 use nom::{
     error::VerboseError,
     number::complete::{be_u32, be_u8},
@@ -309,7 +309,7 @@ impl Request<GetAssertionResult> for GetAssertion {
 impl RequestCtap1 for GetAssertion {
     type Output = GetAssertionResult;
 
-    fn apdu_format<Dev>(&self, dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+    fn ctap1_format<Dev>(&self, dev: &mut Dev) -> Result<Vec<u8>, HIDError>
     where
         Dev: io::Read + io::Write + fmt::Debug + FidoDevice,
     {
@@ -327,7 +327,7 @@ impl RequestCtap1 for GetAssertion {
         impl<'assertion> RequestCtap1 for GetAssertionCheck<'assertion> {
             type Output = ();
 
-            fn apdu_format<Dev>(&self, _dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+            fn ctap1_format<Dev>(&self, _dev: &mut Dev) -> Result<Vec<u8>, HIDError>
             where
                 Dev: U2FDevice + io::Read + io::Write + fmt::Debug,
             {
@@ -347,7 +347,7 @@ impl RequestCtap1 for GetAssertion {
                 auth_data.extend_from_slice(&[self.key_handle.len() as u8]);
                 auth_data.extend_from_slice(self.key_handle);
                 let cmd = U2F_AUTHENTICATE;
-                let apdu = U2FAPDUHeader::serialize(cmd, flags, &auth_data)?;
+                let apdu = CTAP1RequestAPDU::serialize(cmd, flags, &auth_data)?;
                 Ok(apdu)
             }
 
@@ -372,7 +372,7 @@ impl RequestCtap1 for GetAssertion {
                     client_data: &self.client_data,
                     rp: &self.rp,
                 };
-                let res = dev.send_apdu(&check_command);
+                let res = dev.send_ctap1(&check_command);
                 match res {
                     Ok(_) => Some(allowed_handle.id.clone()),
                     _ => None,
@@ -408,7 +408,7 @@ impl RequestCtap1 for GetAssertion {
         auth_data.extend_from_slice(key_handle.as_ref());
 
         let cmd = U2F_AUTHENTICATE;
-        let apdu = U2FAPDUHeader::serialize(cmd, flags, &auth_data)?;
+        let apdu = CTAP1RequestAPDU::serialize(cmd, flags, &auth_data)?;
         Ok(apdu)
     }
 
@@ -925,7 +925,7 @@ pub mod test {
             U2F_CHECK_IS_REGISTERED,
             SW_CONDITIONS_NOT_SATISFIED,
         );
-        let ctap1_request = assertion.apdu_format(&mut device).unwrap();
+        let ctap1_request = assertion.ctap1_format(&mut device).unwrap();
         // Check if the request is going to be correct
         assert_eq!(ctap1_request, GET_ASSERTION_SAMPLE_REQUEST_CTAP1);
 
@@ -938,7 +938,7 @@ pub mod test {
         );
         fill_device_ctap1(&mut device, cid, U2F_REQUEST_USER_PRESENCE, SW_NO_ERROR);
 
-        let response = device.send_apdu(&assertion).unwrap();
+        let response = device.send_ctap1(&assertion).unwrap();
 
         // Check if response is correct
         let expected_auth_data = AuthenticatorData {
@@ -989,11 +989,11 @@ pub mod test {
 
     const GET_ASSERTION_SAMPLE_REQUEST_CTAP1: [u8; 138] = [
         // CBOR Header
-        0x0, // leading zero
-        0x2, // CMD U2F_Authenticate
-        0x3, // Flags (user presence)
-        0x0, 0x0, // zero bits
-        0x0, 0x81, // size
+        0x0, // CLA
+        0x2, // INS U2F_Authenticate
+        0x3, // P1 Flags (user presence)
+        0x0, // P2
+        0x0, 0x0, 0x81, // Lc
         // NOTE: This has been taken from CTAP2.0 spec, but the clientDataHash has been replaced
         //       to be able to operate with known values for CollectedClientData (spec doesn't say
         //       what values led to the provided example hash)
@@ -1012,7 +1012,9 @@ pub mod test {
         0xAC, 0x7B, 0x2B, 0x9C, 0x5C, 0xEF, 0x17, 0x36, 0xC3, 0x71, 0x7D, 0xA4, 0x85, 0x34, 0xC8,
         0xC6, 0xB6, 0x54, 0xD7, 0xFF, 0x94, 0x5F, 0x50, 0xB5, 0xCC, 0x4E, 0x78, 0x05, 0x5B, 0xDD,
         0x39, 0x6B, 0x64, 0xF7, 0x8D, 0xA2, 0xC5, 0xF9, 0x62, 0x00, 0xCC, 0xD4, 0x15, 0xCD, 0x08,
-        0xFE, 0x42, 0x00, 0x38, 0x0, 0x0, // 2 trailing zeros from protocol
+        0xFE, 0x42, 0x00, 0x38, // ..
+        // Le (Ne=65536):
+        0x0, 0x0,
     ];
 
     const GET_ASSERTION_SAMPLE_REQUEST_CTAP2: [u8; 138] = [

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -1,7 +1,7 @@
 use super::{CommandError, RequestCtap1, Retryable};
 use crate::consts::U2F_VERSION;
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::u2ftypes::U2FAPDUHeader;
+use crate::u2ftypes::CTAP1RequestAPDU;
 use crate::u2ftypes::U2FDevice;
 
 #[allow(non_camel_case_types)]
@@ -42,14 +42,14 @@ impl RequestCtap1 for GetVersion {
         }
     }
 
-    fn apdu_format<Dev>(&self, _dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+    fn ctap1_format<Dev>(&self, _dev: &mut Dev) -> Result<Vec<u8>, HIDError>
     where
         Dev: U2FDevice,
     {
         let flags = 0;
 
         let cmd = U2F_VERSION;
-        let data = U2FAPDUHeader::serialize(cmd, flags, &[])?;
+        let data = CTAP1RequestAPDU::serialize(cmd, flags, &[])?;
         Ok(data)
     }
 }
@@ -92,8 +92,8 @@ pub mod tests {
 
         // ctap1 U2F_VERSION request
         let mut msg = cid.to_vec();
-        msg.extend(&[HIDCmd::Msg.into(), 0x0, 0x9]); // cmd + bcnt
-        msg.extend(&[0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]);
+        msg.extend(&[HIDCmd::Msg.into(), 0x0, 0x7]); // cmd + bcnt
+        msg.extend(&[0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0]);
         device.add_write(&msg, 0);
 
         // fido response

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -56,10 +56,14 @@ impl<T> From<T> for Retryable<T> {
 pub trait RequestCtap1: fmt::Debug {
     type Output;
 
-    fn apdu_format<Dev>(&self, dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+    /// Serializes a request into FIDO v1.x / CTAP1 / U2F format.
+    ///
+    /// See [`crate::u2ftypes::CTAP1RequestAPDU::serialize()`]
+    fn ctap1_format<Dev>(&self, dev: &mut Dev) -> Result<Vec<u8>, HIDError>
     where
         Dev: FidoDevice + Read + Write + fmt::Debug;
 
+    /// Deserializes a response from FIDO v1.x / CTAP1 / U2Fv2 format.
     fn handle_response_ctap1(
         &self,
         status: Result<(), ApduErrorStatus>,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -89,7 +89,7 @@ pub trait FidoDevice: HIDDevice {
         if self.supports_ctap2() && msg.is_ctap2_request() {
             self.send_cbor(msg)
         } else {
-            self.send_apdu(msg)
+            self.send_ctap1(msg)
         }
     }
 
@@ -121,12 +121,12 @@ pub trait FidoDevice: HIDDevice {
         }
     }
 
-    fn send_apdu<'msg, Req: RequestCtap1>(
+    fn send_ctap1<'msg, Req: RequestCtap1>(
         &mut self,
         msg: &'msg Req,
     ) -> Result<Req::Output, HIDError> {
         debug!("sending {:?} to {:?}", msg, self);
-        let data = msg.apdu_format(self)?;
+        let data = msg.ctap1_format(self)?;
 
         loop {
             let (cmd, mut data) = self.sendrecv(HIDCmd::Msg, &data)?;
@@ -175,7 +175,7 @@ pub trait FidoDevice: HIDDevice {
         if self.supports_ctap1() {
             let command = GetVersion::default();
             // We don't really use the result here
-            self.send_apdu(&command)?;
+            self.send_ctap1(&command)?;
         }
         Ok(resp)
     }

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -204,28 +204,98 @@ impl U2FHIDInitResp {
     }
 }
 
-// https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit
-// https://fidoalliance.org/specs/fido-u2f-v1.
-// 0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
-pub struct U2FAPDUHeader {}
+/// CTAP1 (FIDO v1.x / U2F / "APDU-like") request framing format, used for
+/// communication with authenticators over *all* transports.
+///
+/// This implementation follows the [FIDO v1.2 spec][fido12rawf], but only
+/// implements extended APDUs (supported by USB HID, NFC and BLE transports).
+///
+/// # Technical details
+///
+/// FIDO v1.0 U2F framing [claims][fido10rawf] to be based on
+/// [ISO/IEC 7816-4:2005][iso7816] (smart card) APDUs, but has several
+/// differences, errors and omissions which make it incompatible.
+///
+/// FIDO v1.1 and v1.2 fixed *most* of these issues, but as a result is *not*
+/// fully compatible with the FIDO v1.0 specification:
+///
+/// * FIDO v1.0 *only* defines extended APDUs, though
+///   [v1.0 NFC implementors][fido10nfc] need to also handle short APDUs.
+///
+///   FIDO v1.1 and later define *both* short and extended APDUs, but defers to
+///   transport-level guidance about which to use (where extended APDU support
+///   is mandatory for all transports, and short APDU support is only mandatory
+///   for NFC transports).
+///
+/// * FIDO v1.0 doesn't special-case N<sub>c</sub> (command data length) = 0
+///   (ie: L<sub>c</sub> is *always* present).
+///
+/// * FIDO v1.0 declares extended L<sub>c</sub> as a 24-bit integer, rather than
+///   16-bit with padding byte.
+///
+/// * FIDO v1.0 omits L<sub>e</sub> bytes entirely,
+///   [except for short APDUs over NFC][fido10nfc].
+///
+/// Unfortunately, FIDO v2.x gives ambiguous compatibility guidance:
+///
+/// * [The FIDO v2.0 spec describes framing][fido20u2f] in
+///   [FIDO v1.0 U2F Raw Message Format][fido10rawf], [cites][fido20u2fcite] the
+///   FIDO v1.0 format by *name*, but actually links to the
+///   [FIDO v1.2 format][fido12rawf].
+///
+/// * [The FIDO v2.1 spec also describes framing][fido21u2f] in
+///   [FIDO v1.0 U2F Raw Message Format][fido10rawf], but [cites][fido21u2fcite]
+///   the [FIDO v1.2 U2F Raw Message Format][fido12rawf] as a reference by name
+///   and URL.
+///
+/// [fido10nfc]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-nfc-protocol.html#framing
+/// [fido10raw]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html
+/// [fido10rawf]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
+/// [fido12rawf]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#u2f-message-framing
+/// [fido20u2f]: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#u2f-framing
+/// [fido20u2fcite]: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#biblio-u2frawmsgs
+/// [fido21u2f]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-framing
+/// [fido21u2fcite]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#biblio-u2frawmsgs
+/// [iso7816]: https://www.iso.org/standard/36134.html
+pub struct CTAP1RequestAPDU {}
 
-impl U2FAPDUHeader {
+impl CTAP1RequestAPDU {
+    /// Serializes a CTAP command into
+    /// [FIDO v1.2 U2F Raw Message Format][fido12raw]. See
+    /// [the struct documentation][Self] for implementation notes.
+    ///
+    /// # Arguments
+    ///
+    /// * `ins`: U2F command code, as documented in
+    ///   [FIDO v1.2 U2F Raw Format][fido12cmd].
+    /// * `p1`: Command parameter 1 / control byte.
+    /// * `data`: Request data, as documented in
+    ///   [FIDO v1.2 Raw Message Formats][fido12raw], of up to 65535 bytes.
+    ///
+    /// [fido12cmd]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#command-and-parameter-values
+    /// [fido12raw]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html
     pub fn serialize(ins: u8, p1: u8, data: &[u8]) -> io::Result<Vec<u8>> {
         if data.len() > 0xffff {
             return Err(io_err("payload length > 2^16"));
         }
+        // Size of header + data.
+        let data_size = if data.is_empty() { 0 } else { 2 + data.len() };
+        let mut bytes = vec![0u8; U2FAPDUHEADER_SIZE + data_size];
 
-        // Size of header + data + 2 zero bytes for maximum return size.
-        let mut bytes = vec![0u8; U2FAPDUHEADER_SIZE + data.len() + 2];
-        // cla is always 0 for our requirements
+        // bytes[0] (CLA): Always 0 in FIDO v1.x.
         bytes[1] = ins;
         bytes[2] = p1;
-        // p2 is always 0, at least, for our requirements.
-        // lc[0] should always be 0.
-        bytes[5] = (data.len() >> 8) as u8;
-        bytes[6] = data.len() as u8;
-        bytes[7..7 + data.len()].copy_from_slice(data);
+        // bytes[3] (P2): Always 0 in FIDO v1.x.
 
+        // bytes[4] (Lc1/Le1): Always 0 for extended APDUs.
+        if !data.is_empty() {
+            bytes[5] = (data.len() >> 8) as u8; // Lc2
+            bytes[6] = data.len() as u8; // Lc3
+
+            bytes[7..7 + data.len()].copy_from_slice(data);
+        }
+
+        // Last two bytes (Le): Always 0 for Ne = 65536
         Ok(bytes)
     }
 }
@@ -254,5 +324,40 @@ impl fmt::Display for U2FDeviceInfo {
             &self.version_build,
             to_hex(&[self.cap_flags.bits()], ":"),
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::CTAP1RequestAPDU;
+
+    #[test]
+    fn test_ctap1_serialize() {
+        // Command with no data, Lc should be omitted.
+        assert_eq!(
+            vec![0, 1, 2, 0, 0, 0, 0],
+            CTAP1RequestAPDU::serialize(1, 2, &[]).unwrap()
+        );
+
+        // Command with data, Lc should be included.
+        assert_eq!(
+            vec![0, 1, 2, 0, 0, 0, 1, 42, 0, 0],
+            CTAP1RequestAPDU::serialize(1, 2, &[42]).unwrap()
+        );
+
+        // Command with 300 bytes data, longer Lc.
+        let d = [0xFF; 300];
+        let mut expected = vec![0, 1, 2, 0, 0, 0x1, 0x2c];
+        expected.extend_from_slice(&d);
+        expected.extend_from_slice(&[0, 0]); // Lc
+        assert_eq!(expected, CTAP1RequestAPDU::serialize(1, 2, &d).unwrap());
+
+        // Command with 64k of data should error
+        let big = [0xFF; 65536];
+        assert!(CTAP1RequestAPDU::serialize(1, 2, &big).is_err());
     }
 }


### PR DESCRIPTION
Addresses #190 on the `ctap2-2021` branch. The issues described here also affect the `main` branch (see #191).

* Fixes an issue where Lc bytes would be included when Nc = 0 (zero command data length). This is incorrect in ISO 7816-4:2005 (which FIDO v1.1 and v1.2 correctly describe).

  This affected the `GetVersion` command; and tests have been updated accordingly.

* Renames `U2FAPDUHeader` to `CTAP1RequestAPDU`.

  Using the name "CTAP1" rather than "U2F" follows the convention put forward in FIDO v2.x specs, which avoids confusion like "U2Fv2" = "CTAP1".

  The previous implementation wasn't just "a header", but rather the complete APDU.

* Renames `RequestCtap1::apdu_format` to `RequestCtap1::ctap1_format` and `FidoDevice::send_apdu` to `FidoDevice::send_ctap1`. This makes it more like `RequestCtap2`, and avoids confusion later on when adding support for CTAP2 over NFC (which still uses ISO 7816-4 APDUs).

* Documents and add tests for `CTAP1RequestAPDU`, explaining the confusing state of affairs.

* Corrects comments for sample CTAP1 requests in tests.