### PR TITLE
Rename and document `U2FAPDUHeader` and fix Nc=0 (main branch)

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,7 +6,15 @@
 #![allow(dead_code)]
 
 pub const MAX_HID_RPT_SIZE: usize = 64;
+
+/// Minimum size of the U2F Raw Message header (FIDO v1.x) in extended mode,
+/// including expected response length (L<sub>e</sub>).
+///
+/// Fields `CLA`, `INS`, `P1` and `P2` are 1 byte each, and L<sub>e</sub> is 3
+/// bytes. If there is a data payload, add 2 bytes (L<sub>c</sub> is 3 bytes,
+/// and L<sub>e</sub> is 2 bytes).
 pub const U2FAPDUHEADER_SIZE: usize = 7;
+
 pub const CID_BROADCAST: [u8; 4] = [0xff, 0xff, 0xff, 0xff];
 pub const TYPE_MASK: u8 = 0x80;
 pub const TYPE_INIT: u8 = 0x80;

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -202,28 +202,98 @@ impl U2FHIDInitResp {
     }
 }
 
-// https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit
-// https://fidoalliance.org/specs/fido-u2f-v1.
-// 0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
-pub struct U2FAPDUHeader {}
+/// CTAP1 (FIDO v1.x / U2F / "APDU-like") request framing format, used for
+/// communication with authenticators over *all* transports.
+///
+/// This implementation follows the [FIDO v1.2 spec][fido12rawf], but only
+/// implements extended APDUs (supported by USB HID, NFC and BLE transports).
+///
+/// # Technical details
+///
+/// FIDO v1.0 U2F framing [claims][fido10rawf] to be based on
+/// [ISO/IEC 7816-4:2005][iso7816] (smart card) APDUs, but has several
+/// differences, errors and omissions which make it incompatible.
+///
+/// FIDO v1.1 and v1.2 fixed *most* of these issues, but as a result is *not*
+/// fully compatible with the FIDO v1.0 specification:
+///
+/// * FIDO v1.0 *only* defines extended APDUs, though
+///   [v1.0 NFC implementors][fido10nfc] need to also handle short APDUs.
+///
+///   FIDO v1.1 and later define *both* short and extended APDUs, but defers to
+///   transport-level guidance about which to use (where extended APDU support
+///   is mandatory for all transports, and short APDU support is only mandatory
+///   for NFC transports).
+///
+/// * FIDO v1.0 doesn't special-case N<sub>c</sub> (command data length) = 0
+///   (ie: L<sub>c</sub> is *always* present).
+///
+/// * FIDO v1.0 declares extended L<sub>c</sub> as a 24-bit integer, rather than
+///   16-bit with padding byte.
+///
+/// * FIDO v1.0 omits L<sub>e</sub> bytes entirely,
+///   [except for short APDUs over NFC][fido10nfc].
+///
+/// Unfortunately, FIDO v2.x gives ambiguous compatibility guidance:
+///
+/// * [The FIDO v2.0 spec describes framing][fido20u2f] in
+///   [FIDO v1.0 U2F Raw Message Format][fido10rawf], [cites][fido20u2fcite] the
+///   FIDO v1.0 format by *name*, but actually links to the
+///   [FIDO v1.2 format][fido12rawf].
+///
+/// * [The FIDO v2.1 spec also describes framing][fido21u2f] in
+///   [FIDO v1.0 U2F Raw Message Format][fido10rawf], but [cites][fido21u2fcite]
+///   the [FIDO v1.2 U2F Raw Message Format][fido12rawf] as a reference by name
+///   and URL.
+///
+/// [fido10nfc]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-nfc-protocol.html#framing
+/// [fido10raw]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html
+/// [fido10rawf]: https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#u2f-message-framing
+/// [fido12rawf]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#u2f-message-framing
+/// [fido20u2f]: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#u2f-framing
+/// [fido20u2fcite]: https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#biblio-u2frawmsgs
+/// [fido21u2f]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-framing
+/// [fido21u2fcite]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#biblio-u2frawmsgs
+/// [iso7816]: https://www.iso.org/standard/36134.html
+pub struct CTAP1RequestAPDU {}
 
-impl U2FAPDUHeader {
+impl CTAP1RequestAPDU {
+    /// Serializes a CTAP command into
+    /// [FIDO v1.2 U2F Raw Message Format][fido12raw]. See
+    /// [the struct documentation][Self] for implementation notes.
+    ///
+    /// # Arguments
+    ///
+    /// * `ins`: U2F command code, as documented in
+    ///   [FIDO v1.2 U2F Raw Format][fido12cmd].
+    /// * `p1`: Command parameter 1 / control byte.
+    /// * `data`: Request data, as documented in
+    ///   [FIDO v1.2 Raw Message Formats][fido12raw], of up to 65535 bytes.
+    ///
+    /// [fido12cmd]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#command-and-parameter-values
+    /// [fido12raw]: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html
     pub fn serialize(ins: u8, p1: u8, data: &[u8]) -> io::Result<Vec<u8>> {
         if data.len() > 0xffff {
             return Err(io_err("payload length > 2^16"));
         }
+        // Size of header + data.
+        let data_size = if data.is_empty() { 0 } else { 2 + data.len() };
+        let mut bytes = vec![0u8; U2FAPDUHEADER_SIZE + data_size];
 
-        // Size of header + data + 2 zero bytes for maximum return size.
-        let mut bytes = vec![0u8; U2FAPDUHEADER_SIZE + data.len() + 2];
-        // cla is always 0 for our requirements
+        // bytes[0] (CLA): Always 0 in FIDO v1.x.
         bytes[1] = ins;
         bytes[2] = p1;
-        // p2 is always 0, at least, for our requirements.
-        // lc[0] should always be 0.
-        bytes[5] = (data.len() >> 8) as u8;
-        bytes[6] = data.len() as u8;
-        bytes[7..7 + data.len()].copy_from_slice(data);
+        // bytes[3] (P2): Always 0 in FIDO v1.x.
 
+        // bytes[4] (Lc1/Le1): Always 0 for extended APDUs.
+        if !data.is_empty() {
+            bytes[5] = (data.len() >> 8) as u8; // Lc2
+            bytes[6] = data.len() as u8; // Lc3
+
+            bytes[7..7 + data.len()].copy_from_slice(data);
+        }
+
+        // Last two bytes (Le): Always 0 for Ne = 65536
         Ok(bytes)
     }
 }
@@ -252,5 +322,40 @@ impl fmt::Display for U2FDeviceInfo {
             &self.version_build,
             to_hex(&[self.cap_flags], ":"),
         )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::CTAP1RequestAPDU;
+
+    #[test]
+    fn test_ctap1_serialize() {
+        // Command with no data, Lc should be omitted.
+        assert_eq!(
+            vec![0, 1, 2, 0, 0, 0, 0],
+            CTAP1RequestAPDU::serialize(1, 2, &[]).unwrap()
+        );
+
+        // Command with data, Lc should be included.
+        assert_eq!(
+            vec![0, 1, 2, 0, 0, 0, 1, 42, 0, 0],
+            CTAP1RequestAPDU::serialize(1, 2, &[42]).unwrap()
+        );
+
+        // Command with 300 bytes data, longer Lc.
+        let d = [0xFF; 300];
+        let mut expected = vec![0, 1, 2, 0, 0, 0x1, 0x2c];
+        expected.extend_from_slice(&d);
+        expected.extend_from_slice(&[0, 0]); // Lc
+        assert_eq!(expected, CTAP1RequestAPDU::serialize(1, 2, &d).unwrap());
+
+        // Command with 64k of data should error
+        let big = [0xFF; 65536];
+        assert!(CTAP1RequestAPDU::serialize(1, 2, &big).is_err());
     }
 }


### PR DESCRIPTION
Addresses #190 on the `main` branch. The issues described here also affect the `ctap2-2021` branch (see #189).

* Fixes an issue where Lc bytes would be included when Nc = 0 (zero command data length). This is incorrect in ISO 7816-4:2005 (which FIDO v1.1 and v1.2 correctly describe).

  This affected the `GetVersion` command; and tests have been updated accordingly.

* Renames `U2FAPDUHeader` to `CTAP1RequestAPDU`.

  Using the name "CTAP1" rather than "U2F" follows the convention put forward in FIDO v2.x specs, which avoids confusion like "U2Fv2" = "CTAP1".

  The previous implementation wasn't just "a header", but rather the complete APDU.

* Renames `FidoDevice::send_apdu` to `FidoDevice::send_ctap1`. This makes it more like `RequestCtap2`, and avoids confusion later on when adding support for CTAP2 over NFC (which still uses ISO 7816-4 APDUs).

* Documents and add tests for `CTAP1RequestAPDU`, explaining the confusing state of affairs.