### PR TITLE
Using CTAP1-devices and allow_lists, responses should contain the correct key-handle and not None

### DIFF
--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -16,11 +16,13 @@ pub struct GetVersion {}
 
 impl RequestCtap1 for GetVersion {
     type Output = U2FInfo;
+    type AdditionalInfo = ();
 
     fn handle_response_ctap1(
         &self,
         _status: Result<(), ApduErrorStatus>,
         input: &[u8],
+        _add_info: &(),
     ) -> Result<Self::Output, Retryable<HIDError>> {
         if input.is_empty() {
             return Err(Retryable::Error(HIDError::Command(
@@ -36,7 +38,7 @@ impl RequestCtap1 for GetVersion {
         }
     }
 
-    fn ctap1_format<Dev>(&self, _dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+    fn ctap1_format<Dev>(&self, _dev: &mut Dev) -> Result<(Vec<u8>, ()), HIDError>
     where
         Dev: U2FDevice,
     {
@@ -44,7 +46,7 @@ impl RequestCtap1 for GetVersion {
 
         let cmd = U2F_VERSION;
         let data = CTAP1RequestAPDU::serialize(cmd, flags, &[])?;
-        Ok(data)
+        Ok((data, ()))
     }
 }
 

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -55,11 +55,13 @@ impl<T> From<T> for Retryable<T> {
 
 pub trait RequestCtap1: fmt::Debug {
     type Output;
+    // E.g.: For GetAssertion, which key-handle is currently being tested
+    type AdditionalInfo;
 
     /// Serializes a request into FIDO v1.x / CTAP1 / U2F format.
     ///
     /// See [`crate::u2ftypes::CTAP1RequestAPDU::serialize()`]
-    fn ctap1_format<Dev>(&self, dev: &mut Dev) -> Result<Vec<u8>, HIDError>
+    fn ctap1_format<Dev>(&self, dev: &mut Dev) -> Result<(Vec<u8>, Self::AdditionalInfo), HIDError>
     where
         Dev: FidoDevice + Read + Write + fmt::Debug;
 
@@ -68,6 +70,7 @@ pub trait RequestCtap1: fmt::Debug {
         &self,
         status: Result<(), ApduErrorStatus>,
         input: &[u8],
+        add_info: &Self::AdditionalInfo,
     ) -> Result<Self::Output, Retryable<HIDError>>;
 }
 

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -2,7 +2,7 @@
 pub mod commands;
 pub use commands::get_assertion::AssertionObject;
 
-pub(crate) mod attestation;
+pub mod attestation;
 
 pub mod client_data;
 pub mod server;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,13 @@ pub struct KeyHandle {
 
 pub type AppId = Vec<u8>;
 
+#[derive(Debug)]
 pub enum RegisterResult {
     CTAP1(Vec<u8>, u2ftypes::U2FDeviceInfo),
     CTAP2(AttestationObject, CollectedClientDataWrapper),
 }
 
+#[derive(Debug)]
 pub enum SignResult {
     CTAP1(AppId, Vec<u8>, Vec<u8>, u2ftypes::U2FDeviceInfo),
     CTAP2(AssertionObject, CollectedClientDataWrapper),

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -526,7 +526,6 @@ impl StateMachineCtap2 {
                         callback.call(Ok(RegisterResult::CTAP1(data, dev.get_device_info())))
                     }
 
-                    Err(HIDError::DeviceNotSupported) | Err(HIDError::UnsupportedCommand) => {}
                     Err(HIDError::Command(CommandError::StatusCode(
                         StatusCode::ChannelBusy,
                         _,
@@ -636,11 +635,6 @@ impl StateMachineCtap2 {
                     Ok(GetAssertionResult::CTAP2(assertion, client_data)) => {
                         callback.call(Ok(SignResult::CTAP2(assertion, client_data)))
                     }
-                    // TODO(baloo): if key_handle is invalid for this device, it
-                    //              should reply something like:
-                    //              CTAP2_ERR_INVALID_CREDENTIAL
-                    //              have to check
-                    Err(HIDError::DeviceNotSupported) | Err(HIDError::UnsupportedCommand) => {}
                     Err(HIDError::Command(CommandError::StatusCode(
                         StatusCode::ChannelBusy,
                         _,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -114,7 +114,7 @@ pub trait FidoDevice: HIDDevice {
 
     fn send_ctap1<Req: RequestCtap1>(&mut self, msg: &Req) -> Result<Req::Output, HIDError> {
         debug!("sending {:?} to {:?}", msg, self);
-        let data = msg.ctap1_format(self)?;
+        let (data, add_info) = msg.ctap1_format(self)?;
 
         loop {
             let (cmd, mut data) = self.sendrecv(HIDCmd::Msg, &data)?;
@@ -133,7 +133,7 @@ pub trait FidoDevice: HIDDevice {
                 // This will bubble up error if status != no error
                 let status = ApduErrorStatus::from([status[0], status[1]]);
 
-                match msg.handle_response_ctap1(status, &data) {
+                match msg.handle_response_ctap1(status, &data, &add_info) {
                     Ok(out) => return Ok(out),
                     Err(Retryable::Retry) => {
                         // sleep 100ms then loop again


### PR DESCRIPTION
This is not super pretty.
But adding it to the message would require the message to be `mut`, which would have a long tail of changes.
`RefCell` was also not an option, as the message is shared across threads. This would have turned rather clunky to achieve interior mutability.
So now, `ctap1_format()` can return additional info, instead. This is only used for `GetAssertion` for now.
Using that, I'm able to login to github with an CTAP1-token.

I added a test binary for this as well.