### PR TITLE
Add RP ID retry mechanism for FIDO AppID extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authenticator"
-version = "0.4.0-alpha.7"
+version = "0.4.0-alpha.8"
 authors = ["J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>", "Kyle Machulis <kyle@nonpolynomial.com>"]
 keywords = ["ctap2", "u2f", "fido", "webauthn"]
 categories = ["cryptography", "hardware-support", "os"]

--- a/examples/ctap1.rs
+++ b/examples/ctap1.rs
@@ -30,7 +30,7 @@ fn u2f_get_key_handle_from_register_response(register_response: &[u8]) -> io::Re
 }
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -82,7 +82,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -108,13 +108,13 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(..))
             | Ok(StatusUpdate::SelectDeviceNotice)

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -255,6 +255,7 @@ fn main() {
             },
         },
         pin: None,
+        alternate_rp_id: None,
     };
 
     loop {

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -21,7 +21,7 @@ use std::sync::mpsc::{channel, RecvError};
 use std::{env, thread};
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -63,7 +63,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -86,19 +86,19 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(error, sender)) => match error {
                 PinError::PinRequired => {
@@ -111,8 +111,7 @@ fn main() {
                     println!(
                         "Wrong PIN! {}",
                         attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {} attempts left.",
-                            a
+                            "You have {a} attempts left."
                         ))
                     );
                     let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
@@ -281,7 +280,7 @@ fn main() {
         match sign_result {
             Ok(SignResult::CTAP1(..)) => panic!("Requested CTAP2, but got CTAP1 sign results!"),
             Ok(SignResult::CTAP2(assertion_object, _client_data)) => {
-                println!("Assertion Object: {:?}", assertion_object);
+                println!("Assertion Object: {assertion_object:?}");
                 println!("Done.");
                 break;
             }

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -25,7 +25,7 @@ fn print_usage(program: &str, opts: Options) {
     println!("requests 'discoverable credentials' for them.");
     println!("After that, we try to log in to that origin and list all credentials found.");
     println!("------------------------------------------------------------------------");
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -33,8 +33,7 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
     println!();
     println!("*********************************************************************");
     println!(
-        "Asking a security key to register now with user: {}",
-        username
+        "Asking a security key to register now with user: {username}"
     );
     println!("*********************************************************************");
 
@@ -57,19 +56,19 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(error, sender)) => match error {
                 PinError::PinRequired => {
@@ -82,8 +81,7 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
                     println!(
                         "Wrong PIN! {}",
                         attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {} attempts left.",
-                            a
+                            "You have {a} attempts left."
                         ))
                     );
                     let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
@@ -218,7 +216,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -246,19 +244,19 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(error, sender)) => match error {
                 PinError::PinRequired => {
@@ -271,8 +269,7 @@ fn main() {
                     println!(
                         "Wrong PIN! {}",
                         attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {} attempts left.",
-                            a
+                            "You have {a} attempts left."
                         ))
                     );
                     let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")
@@ -334,7 +331,7 @@ fn main() {
         match sign_result {
             Ok(SignResult::CTAP1(..)) => panic!("Requested CTAP2, but got CTAP1 sign results!"),
             Ok(SignResult::CTAP2(assertion_object, _client_data)) => {
-                println!("Assertion Object: {:?}", assertion_object);
+                println!("Assertion Object: {assertion_object:?}");
                 println!("-----------------------------------------------------------------");
                 println!("Found credentials:");
                 println!(

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -308,6 +308,7 @@ fn main() {
         options: GetAssertionOptions::default(),
         extensions: Default::default(),
         pin: None,
+        alternate_rp_id: None,
     };
 
     loop {

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -30,7 +30,7 @@ fn u2f_get_key_handle_from_register_response(register_response: &[u8]) -> io::Re
 }
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -82,7 +82,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -108,13 +108,13 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(..))
             | Ok(StatusUpdate::SelectDeviceNotice)

--- a/examples/reset.rs
+++ b/examples/reset.rs
@@ -14,7 +14,7 @@ use std::env;
 use std::sync::mpsc::{channel, RecvError};
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -55,7 +55,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -106,7 +106,7 @@ fn main() {
                 return;
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
                 break;
             }
             Ok(StatusUpdate::PinError(..)) => panic!("Reset should never ask for a PIN!"),

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc::{channel, RecvError};
 use std::{env, thread};
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -53,7 +53,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -71,19 +71,19 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(error, sender)) => match error {
                 PinError::PinRequired => {
@@ -96,8 +96,7 @@ fn main() {
                     println!(
                         "Wrong PIN! {}",
                         attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {} attempts left.",
-                            a
+                            "You have {a} attempts left."
                         ))
                     );
                     let raw_pin = rpassword::prompt_password_stderr("Enter current PIN: ")

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -21,7 +21,7 @@ use std::sync::mpsc::{channel, RecvError};
 use std::{env, thread};
 
 fn print_usage(program: &str, opts: Options) {
-    let brief = format!("Usage: {} [options]", program);
+    let brief = format!("Usage: {program} [options]");
     print!("{}", opts.usage(&brief));
 }
 
@@ -59,7 +59,7 @@ fn main() {
             timeout_s * 1_000
         }
         Err(e) => {
-            println!("{}", e);
+            println!("{e}");
             print_usage(&program, opts);
             return;
         }
@@ -82,19 +82,19 @@ fn main() {
     thread::spawn(move || loop {
         match status_rx.recv() {
             Ok(StatusUpdate::DeviceAvailable { dev_info }) => {
-                println!("STATUS: device available: {}", dev_info)
+                println!("STATUS: device available: {dev_info}")
             }
             Ok(StatusUpdate::DeviceUnavailable { dev_info }) => {
-                println!("STATUS: device unavailable: {}", dev_info)
+                println!("STATUS: device unavailable: {dev_info}")
             }
             Ok(StatusUpdate::Success { dev_info }) => {
-                println!("STATUS: success using device: {}", dev_info);
+                println!("STATUS: success using device: {dev_info}");
             }
             Ok(StatusUpdate::SelectDeviceNotice) => {
                 println!("STATUS: Please select a device by touching one of them.");
             }
             Ok(StatusUpdate::DeviceSelected(dev_info)) => {
-                println!("STATUS: Continuing with device: {}", dev_info);
+                println!("STATUS: Continuing with device: {dev_info}");
             }
             Ok(StatusUpdate::PinError(error, sender)) => match error {
                 PinError::PinRequired => {
@@ -107,8 +107,7 @@ fn main() {
                     println!(
                         "Wrong PIN! {}",
                         attempts.map_or("Try again.".to_string(), |a| format!(
-                            "You have {} attempts left.",
-                            a
+                            "You have {a} attempts left."
                         ))
                     );
                     let raw_pin = rpassword::prompt_password_stderr("Enter PIN: ")

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -81,6 +81,7 @@ pub struct SignArgsCtap2 {
     pub options: GetAssertionOptions,
     pub extensions: GetAssertionExtensions,
     pub pin: Option<Pin>,
+    pub alternate_rp_id: Option<String>,
     // Todo: Extensions
 }
 
@@ -839,6 +840,7 @@ mod tests {
             options: Default::default(),
             extensions: Default::default(),
             pin: None,
+            alternate_rp_id: None,
         };
         assert!(s
             .sign(

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -490,7 +490,7 @@ impl<'de> Deserialize<'de> for COSEKey {
                             }
                             let value: u64 = map.next_value()?;
                             let val = COSEKeyTypeId::try_from(value).map_err(|_| {
-                                SerdeError::custom(format!("unsupported key_type {}", value))
+                                SerdeError::custom(format!("unsupported key_type {value}"))
                             })?;
                             key_type = Some(val);
                             // key_type = Some(map.next_value()?);
@@ -510,7 +510,7 @@ impl<'de> Deserialize<'de> for COSEKey {
                                 }
                                 let value: u64 = map.next_value()?;
                                 let val = ECDSACurve::try_from(value).map_err(|_| {
-                                    SerdeError::custom(format!("unsupported curve {}", value))
+                                    SerdeError::custom(format!("unsupported curve {value}"))
                                 })?;
                                 curve = Some(val);
                                 // curve = Some(map.next_value()?);
@@ -536,7 +536,7 @@ impl<'de> Deserialize<'de> for COSEKey {
                             }
                             let value: i64 = map.next_value()?;
                             let val = COSEAlgorithm::try_from(value).map_err(|_| {
-                                SerdeError::custom(format!("unsupported algorithm {}", value))
+                                SerdeError::custom(format!("unsupported algorithm {value}"))
                             })?;
                             alg = Some(val);
                             // alg = map.next_value()?;

--- a/src/crypto/nss.rs
+++ b/src/crypto/nss.rs
@@ -33,7 +33,7 @@ pub enum BackendError {
 
 impl From<NSSError> for BackendError {
     fn from(e: NSSError) -> Self {
-        BackendError::NSSError(format!("{}", e))
+        BackendError::NSSError(format!("{e}"))
     }
 }
 

--- a/src/ctap2-capi.h
+++ b/src/ctap2-capi.h
@@ -15,6 +15,7 @@ const uint8_t CTAP2_SIGN_RESULT_AUTH_DATA = 2;
 const uint8_t CTAP2_SIGN_RESULT_SIGNATURE = 3;
 const uint8_t CTAP2_SIGN_RESULT_USER_ID = 4;
 const uint8_t CTAP2_SIGN_RESULT_USER_NAME = 5;
+const uint8_t CTAP2_SIGN_RESULT_RP_ID_HASH = 6;
 
 typedef struct {
     const uint8_t *id_ptr;
@@ -93,7 +94,7 @@ uint64_t rust_ctap2_mgr_register(
 uint64_t rust_ctap2_mgr_sign(
     rust_ctap_manager* mgr, uint64_t timeout, rust_ctap2_sign_callback, rust_ctap2_status_update_callback,
     AuthenticatorArgsChallenge challenge,
-    const char* relying_party_id, const char *origin_ptr,
+    const char* relying_party_id, const char* alternate_relying_party_id, const char *origin_ptr,
     const rust_ctap2_pub_key_cred_descriptors* allow_list, AuthenticatorArgsOptions options,
     const char *pin
 );

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -321,7 +321,7 @@ pub struct Signature(#[serde(with = "serde_bytes")] pub(crate) ByteBuf);
 impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = base64::encode_config(&self.0, base64::URL_SAFE_NO_PAD);
-        write!(f, "Signature({})", value)
+        write!(f, "Signature({value})")
     }
 }
 
@@ -494,7 +494,7 @@ impl<'de> Deserialize<'de> for AttestationObject {
                                 }
                             }
                         }
-                        k => return Err(M::Error::custom(format!("unexpected key: {:?}", k))),
+                        k => return Err(M::Error::custom(format!("unexpected key: {k:?}"))),
                     }
                 }
 
@@ -748,7 +748,7 @@ mod test {
     #[test]
     fn parse_attestation_object() {
         let value: AttestationObject = from_slice(&SAMPLE_ATTESTATION).unwrap();
-        println!("{:?}", value);
+        println!("{value:?}");
 
         //assert_eq!(true, false);
     }
@@ -795,7 +795,7 @@ mod test {
         ];
         let expected = "AAGuid(cb69481e-8ff0-0039-93ec-0a2729a154a8)";
         let result = AAGuid::from(&input).expect("Failed to parse AAGuid");
-        let res_str = format!("{:?}", result);
+        let res_str = format!("{result:?}");
         assert_eq!(expected, &res_str);
     }
 }

--- a/src/ctap2/client_data.rs
+++ b/src/ctap2/client_data.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for TokenBinding {
                             id = Some(map.next_value()?);
                         }
                         k => {
-                            return Err(M::Error::custom(format!("unexpected key: {:?}", k)));
+                            return Err(M::Error::custom(format!("unexpected key: {k:?}")));
                         }
                     }
                 }
@@ -107,7 +107,7 @@ impl<'de> Deserialize<'de> for TokenBinding {
                             }
                         }
                         "supported" => Ok(TokenBinding::Supported),
-                        k => Err(M::Error::custom(format!("unexpected status key: {:?}", k))),
+                        k => Err(M::Error::custom(format!("unexpected status key: {k:?}"))),
                     }
                 } else {
                     Err(SerdeError::missing_field("status"))

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -751,12 +751,12 @@ impl fmt::Display for PinError {
         match *self {
             PinError::PinRequired => write!(f, "PinError: Pin required."),
             PinError::PinIsTooShort => write!(f, "PinError: pin is too short"),
-            PinError::PinIsTooLong(len) => write!(f, "PinError: pin is too long ({})", len),
+            PinError::PinIsTooLong(len) => write!(f, "PinError: pin is too long ({len})"),
             PinError::InvalidKeyLen => write!(f, "PinError: invalid key len"),
             PinError::InvalidPin(ref e) => {
                 let mut res = write!(f, "PinError: Invalid Pin.");
                 if let Some(pin_retries) = e {
-                    res = write!(f, " Retries left: {:?}", pin_retries)
+                    res = write!(f, " Retries left: {pin_retries:?}")
                 }
                 res
             }
@@ -769,7 +769,7 @@ impl fmt::Display for PinError {
                 "PinError: No retries left. Pin blocked. Device needs reset."
             ),
             PinError::PinNotSet => write!(f, "PinError: Pin needed but not set on device."),
-            PinError::Backend(ref e) => write!(f, "PinError: Crypto backend error: {:?}", e),
+            PinError::Backend(ref e) => write!(f, "PinError: Crypto backend error: {e:?}"),
         }
     }
 }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -190,6 +190,9 @@ pub struct GetAssertion {
     pub(crate) options: GetAssertionOptions,
     pub(crate) pin: Option<Pin>,
     pub(crate) pin_auth: Option<PinAuth>,
+
+    // This is used to implement the FIDO AppID extension.
+    pub(crate) alternate_rp_id: Option<String>,
     //TODO(MS): pinProtocol
 }
 
@@ -201,6 +204,7 @@ impl GetAssertion {
         options: GetAssertionOptions,
         extensions: GetAssertionExtensions,
         pin: Option<Pin>,
+        alternate_rp_id: Option<String>,
     ) -> Result<Self, HIDError> {
         let client_data_wrapper = CollectedClientDataWrapper::new(client_data_wrapper)?;
         Ok(Self {
@@ -211,6 +215,7 @@ impl GetAssertion {
             options,
             pin,
             pin_auth: None,
+            alternate_rp_id,
         })
     }
 }
@@ -720,6 +725,7 @@ pub mod test {
             },
             Default::default(),
             None,
+            None,
         )
         .expect("Failed to create GetAssertion");
         let mut device = Device::new("commands/get_assertion").unwrap();
@@ -929,6 +935,7 @@ pub mod test {
             },
             Default::default(),
             None,
+            None,
         )
         .expect("Failed to create GetAssertion");
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
@@ -1021,6 +1028,7 @@ pub mod test {
                 user_verification: None,
             },
             Default::default(),
+            None,
             None,
         )
         .expect("Failed to create GetAssertion");

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -647,7 +647,7 @@ impl<'de> Deserialize<'de> for GetAssertionResponse {
                             }
                             number_of_credentials = Some(map.next_value()?);
                         }
-                        k => return Err(M::Error::custom(format!("unexpected key: {:?}", k))),
+                        k => return Err(M::Error::custom(format!("unexpected key: {k:?}"))),
                     }
                 }
 

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -681,8 +681,7 @@ pub mod test {
             .expect("Failed to serialize MakeCredentials request");
         assert_eq!(
             req_serialized, MAKE_CREDENTIALS_SAMPLE_REQUEST_CTAP1,
-            "\nGot:      {:X?}\nExpected: {:X?}",
-            req_serialized, MAKE_CREDENTIALS_SAMPLE_REQUEST_CTAP1
+            "\nGot:      {req_serialized:X?}\nExpected: {MAKE_CREDENTIALS_SAMPLE_REQUEST_CTAP1:X?}"
         );
         let (attestation_object, _collected_client_data) = match req
             .handle_response_ctap1(Ok(()), &MAKE_CREDENTIALS_SAMPLE_RESPONSE_CTAP1, &())

--- a/src/ctap2/commands/mod.rs
+++ b/src/ctap2/commands/mod.rs
@@ -400,19 +400,19 @@ impl fmt::Display for CommandError {
         match *self {
             CommandError::InputTooSmall => write!(f, "CommandError: Input is too small"),
             CommandError::MissingRequiredField(field) => {
-                write!(f, "CommandError: Missing required field {}", field)
+                write!(f, "CommandError: Missing required field {field}")
             }
             CommandError::Deserializing(ref e) => {
-                write!(f, "CommandError: Error while parsing: {}", e)
+                write!(f, "CommandError: Error while parsing: {e}")
             }
             CommandError::Serializing(ref e) => {
-                write!(f, "CommandError: Error while serializing: {}", e)
+                write!(f, "CommandError: Error while serializing: {e}")
             }
             CommandError::StatusCode(ref code, ref value) => {
-                write!(f, "CommandError: Unexpected code: {:?} ({:?})", code, value)
+                write!(f, "CommandError: Unexpected code: {code:?} ({value:?})")
             }
-            CommandError::Json(ref e) => write!(f, "CommandError: Json serializing error: {}", e),
-            CommandError::Crypto(ref e) => write!(f, "CommandError: Crypto error: {:?}", e),
+            CommandError::Json(ref e) => write!(f, "CommandError: Json serializing error: {e}"),
+            CommandError::Crypto(ref e) => write!(f, "CommandError: Crypto error: {e:?}"),
             CommandError::UnsupportedPinProtocol => {
                 write!(f, "CommandError: Pin protocol is not supported")
             }

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -17,7 +17,7 @@ pub struct RpIdHash(pub [u8; 32]);
 impl fmt::Debug for RpIdHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value = base64::encode_config(self.0, base64::URL_SAFE_NO_PAD);
-        write!(f, "RpIdHash({})", value)
+        write!(f, "RpIdHash({value})")
     }
 }
 
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for PublicKeyCredentialParameters {
 
                             let v: &str = map.next_value()?;
                             if v != "public-key" {
-                                return Err(SerdeError::custom(format!("invalid value: {}", v)));
+                                return Err(SerdeError::custom(format!("invalid value: {v}")));
                             }
                             found_type = true;
                         }
@@ -266,7 +266,7 @@ impl<'de> Deserialize<'de> for PublicKeyCredentialDescriptor {
                             }
                             let v: &str = map.next_value()?;
                             if v != "public-key" {
-                                return Err(SerdeError::custom(format!("invalid value: {}", v)));
+                                return Err(SerdeError::custom(format!("invalid value: {v}")));
                             }
                             found_type = true;
                         }
@@ -342,7 +342,7 @@ mod test {
         };
 
         let payload = ser::to_vec(&user).unwrap();
-        println!("payload = {:?}", payload);
+        println!("payload = {payload:?}");
         assert_eq!(
             payload,
             vec![
@@ -394,7 +394,7 @@ mod test {
         };
 
         let payload = ser::to_vec(&user).unwrap();
-        println!("payload = {:?}", payload);
+        println!("payload = {payload:?}");
         assert_eq!(
             payload,
             vec![
@@ -431,7 +431,7 @@ mod test {
         ];
 
         let payload = ser::to_vec(&keys);
-        println!("payload = {:?}", payload);
+        println!("payload = {payload:?}");
         let payload = payload.unwrap();
         assert_eq!(
             payload,
@@ -471,7 +471,7 @@ mod test {
         };
 
         let payload = ser::to_vec(&key);
-        println!("payload = {:?}", payload);
+        println!("payload = {payload:?}");
         let payload = payload.unwrap();
 
         assert_eq!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -64,23 +64,22 @@ impl fmt::Display for AuthenticatorError {
                 "no transports were configured in the authenticator service"
             ),
             AuthenticatorError::Platform => write!(f, "unknown platform error"),
-            AuthenticatorError::InternalError(ref err) => write!(f, "internal error: {}", err),
+            AuthenticatorError::InternalError(ref err) => write!(f, "internal error: {err}"),
             AuthenticatorError::U2FToken(ref err) => {
-                write!(f, "A u2f token error occurred {:?}", err)
+                write!(f, "A u2f token error occurred {err:?}")
             }
-            AuthenticatorError::Custom(ref err) => write!(f, "A custom error occurred {:?}", err),
+            AuthenticatorError::Custom(ref err) => write!(f, "A custom error occurred {err:?}"),
             AuthenticatorError::VersionMismatch(manager, version) => write!(
                 f,
-                "{} expected arguments of version CTAP{}",
-                manager, version
+                "{manager} expected arguments of version CTAP{version}"
             ),
-            AuthenticatorError::HIDError(ref e) => write!(f, "Device error: {}", e),
+            AuthenticatorError::HIDError(ref e) => write!(f, "Device error: {e}"),
             AuthenticatorError::CryptoError => {
                 write!(f, "The cryptography implementation encountered an error")
             }
-            AuthenticatorError::PinError(ref e) => write!(f, "PIN Error: {}", e),
+            AuthenticatorError::PinError(ref e) => write!(f, "PIN Error: {e}"),
             AuthenticatorError::UnsupportedOption(ref e) => {
-                write!(f, "Unsupported option: {:?}", e)
+                write!(f, "Unsupported option: {e:?}")
             }
         }
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -495,6 +495,7 @@ impl AuthenticatorTransport for Manager {
                             options,
                             Default::default(),
                             None,
+                            None,
                         )?;
 
                         let action = QueueAction::SignCtap2 {
@@ -528,6 +529,7 @@ impl AuthenticatorTransport for Manager {
                     args.options,
                     args.extensions,
                     args.pin,
+                    args.alternate_rp_id,
                 )?;
 
                 let action = QueueAction::SignCtap2 {

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -325,7 +325,7 @@ pub mod tests {
         add_devices(devices.iter(), &selector);
         devices.iter_mut().for_each(|d| {
             if !d.is_u2f() {
-                send_no_token(&d, &selector);
+                send_no_token(d, &selector);
             }
         });
 

--- a/src/transport/errors.rs
+++ b/src/transport/errors.rs
@@ -31,7 +31,7 @@ impl fmt::Display for ApduErrorStatus {
             ApduErrorStatus::ConditionsNotSatisfied => write!(f, "Apdu: condition not satisfied"),
             ApduErrorStatus::WrongData => write!(f, "Apdu: wrong data"),
             ApduErrorStatus::WrongLength => write!(f, "Apdu: wrong length"),
-            ApduErrorStatus::Unknown(ref u) => write!(f, "Apdu: unknown error: {:?}", u),
+            ApduErrorStatus::Unknown(ref u) => write!(f, "Apdu: unknown error: {u:?}"),
         }
     }
 }
@@ -87,11 +87,11 @@ impl fmt::Display for HIDError {
             HIDError::UnsupportedCommand => {
                 write!(f, "Error: command is not supported on this device")
             }
-            HIDError::IO(ref p, ref e) => write!(f, "Error: Ioerror({:?}): {}", p, e),
-            HIDError::Command(ref e) => write!(f, "Error: Error issuing command: {}", e),
-            HIDError::UnexpectedCmd(s) => write!(f, "Error: Unexpected status: {}", s),
+            HIDError::IO(ref p, ref e) => write!(f, "Error: Ioerror({p:?}): {e}"),
+            HIDError::Command(ref e) => write!(f, "Error: Error issuing command: {e}"),
+            HIDError::UnexpectedCmd(s) => write!(f, "Error: Unexpected status: {s}"),
             HIDError::ApduStatus(ref status) => {
-                write!(f, "Error: Unexpected apdu status: {:?}", status)
+                write!(f, "Error: Unexpected apdu status: {status:?}")
             }
         }
     }

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -39,20 +39,14 @@ impl Device {
         if prop_ref.is_null() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!(
-                    "IOHIDDeviceGetProperty received nullptr for property {}",
-                    prop_name
-                ),
+                format!("IOHIDDeviceGetProperty received nullptr for property {prop_name}"),
             ));
         }
 
         if CFGetTypeID(prop_ref) != CFStringGetTypeID() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!(
-                    "IOHIDDeviceGetProperty returned non-string type for property {}",
-                    prop_name
-                ),
+                format!("IOHIDDeviceGetProperty returned non-string type for property {prop_name}"),
             ));
         }
 

--- a/src/transport/macos/monitor.rs
+++ b/src/transport/macos/monitor.rs
@@ -103,7 +103,7 @@ where
             if rv == 0 {
                 Ok(())
             } else {
-                Err(io_err(&format!("Couldn't open HID Manager, rv={}", rv)))
+                Err(io_err(&format!("Couldn't open HID Manager, rv={rv}")))
             }
         }
     }
@@ -145,7 +145,7 @@ where
         let mut send_failed = false;
 
         // Ignore the report if we can't find a device for it.
-        if let Some(&DeviceData { ref tx, .. }) = this.map.get(&device_ref) {
+        if let Some(DeviceData { tx, .. }) = this.map.get(&device_ref) {
             let data = unsafe { slice::from_raw_parts(report, report_len as usize).to_vec() };
             send_failed = tx.send(data).is_err();
         }

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -122,7 +122,7 @@ impl U2FDevice for Device {
     }
 
     fn get_property(&self, prop_name: &str) -> io::Result<String> {
-        Ok(format!("{} not implemented", prop_name))
+        Ok(format!("{prop_name} not implemented"))
     }
     fn get_device_info(&self) -> U2FDeviceInfo {
         self.dev_info.clone().unwrap()

--- a/src/transport/netbsd/monitor.rs
+++ b/src/transport/netbsd/monitor.rs
@@ -66,7 +66,7 @@ where
         // Loop until we're stopped by the controlling thread, or fail.
         while alive() {
             for n in 0..100 {
-                let uhidpath = OsString::from(format!("/dev/uhid{}", n));
+                let uhidpath = OsString::from(format!("/dev/uhid{n}"));
                 match Fd::open(&uhidpath, libc::O_RDWR | libc::O_CLOEXEC) {
                     Ok(uhid) => {
                         // The device is available if it can be opened.

--- a/src/u2fprotocol.rs
+++ b/src/u2fprotocol.rs
@@ -175,7 +175,7 @@ fn status_word_to_result<T>(status: [u8; 2], val: T) -> io::Result<T> {
         SW_WRONG_DATA => Err(io::Error::new(InvalidData, "wrong data")),
         SW_WRONG_LENGTH => Err(io::Error::new(InvalidInput, "wrong length")),
         SW_CONDITIONS_NOT_SATISFIED => Err(io_err("conditions not satisfied")),
-        _ => Err(io_err(&format!("failed with status {:?}", status))),
+        _ => Err(io_err(&format!("failed with status {status:?}"))),
     }
 }
 

--- a/src/u2ftypes.rs
+++ b/src/u2ftypes.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use std::{cmp, fmt, io, str};
 
 pub fn to_hex(data: &[u8], joiner: &str) -> String {
-    let parts: Vec<String> = data.iter().map(|byte| format!("{:02x}", byte)).collect();
+    let parts: Vec<String> = data.iter().map(|byte| format!("{byte:02x}")).collect();
     parts.join(joiner)
 }
 


### PR DESCRIPTION
This allows the `get_assertion` caller to specify an alternate RP ID to use if the authenticator does not find a credential with the primary RP ID.

We'll use this to implement the FIDO AppID WebAuthn extension in Firefox. See also: [Bug 1814722](https://bugzilla.mozilla.org/show_bug.cgi?id=1814722).