### PR TITLE
Correct the order of map keys in serialized AttestationObjects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authenticator"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 authors = ["J.C. Jones <jc@mozilla.com>", "Tim Taubert <ttaubert@mozilla.com>", "Kyle Machulis <kyle@nonpolynomial.com>"]
 keywords = ["ctap2", "u2f", "fido", "webauthn"]
 categories = ["cryptography", "hardware-support", "os"]

--- a/src/ctap2/attestation.rs
+++ b/src/ctap2/attestation.rs
@@ -529,7 +529,8 @@ impl Serialize for AttestationObject {
             .map(serde_cbor::Value::Bytes)
             .map_err(|_| SerError::custom("Failed to serialize auth_data"))?;
 
-        map.serialize_entry(&"authData", &auth_data)?;
+        // CTAP2 canonical CBOR order for these entries is ("fmt", "attStmt", "authData")
+        // as strings are sorted by length and then lexically.
         match self.att_statement {
             AttestationStatement::None => {
                 // Even with Att None, an empty map is returned in the cbor!
@@ -546,6 +547,7 @@ impl Serialize for AttestationObject {
                 map.serialize_entry(&"attStmt", v)?;
             }
         }
+        map.serialize_entry(&"authData", &auth_data)?;
         map.end()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub use ctap2::attestation::AttestationObject;
 pub use ctap2::client_data::{CollectedClientData, CollectedClientDataWrapper};
 pub use ctap2::commands::client_pin::{Pin, PinError};
 pub use ctap2::AssertionObject;
+pub use ctap2::commands::get_assertion::Assertion;
 
 mod ctap2_capi;
 pub use crate::ctap2_capi::*;


### PR DESCRIPTION
Martin Kreichgauer determined that the AttestationObject issue here is the reason Firefox users can't register keys with Google Accounts using this library.

I'm tacking on a small patch to expose the Assertion struct at the top level. This is needed for the XPCOM interface.