### PR TITLE
transports/netbsd: Fix ping read/write operations.

### DIFF
--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -40,7 +40,19 @@ impl Device {
             buf[6] = 0;
             buf[7] = 1; // one byte
 
-            self.write_all(&buf)?;
+            // Write ping request.  Each write to the device contains
+            // exactly one report id byte[*] followed by exactly as
+            // many bytes as are in a report, and will be consumed all
+            // at once by /dev/uhidN.  So we use plain write, not
+            // write_all to issue writes in a loop.
+            //
+            // [*] This is only for the internal authenticator-rs API,
+            // not for the USB HID protocol, which for a device with
+            // only one report id excludes the report id byte from the
+            // interrupt in/out pipe transfer format.
+            if self.write(&buf)? != buf.len() {
+                return Err(io_err("write ping failed"));
+            }
 
             // Wait for response
             let mut pfd: libc::pollfd = unsafe { mem::zeroed() };
@@ -55,8 +67,13 @@ impl Device {
                 continue;
             }
 
-            // Read response
-            self.read_exact(&mut buf)?;
+            // Read response.  When reports come in they are all
+            // exactly the same size, with no report id byte because
+            // there is only one report.
+            let n = self.read(&mut buf[1..])?;
+            if n != buf.len() - 1 {
+                return Err(io_err("read pong failed"));
+            }
 
             return Ok(());
         }


### PR DESCRIPTION
The internal authenticator-rs Device API expects the following format for n-byte reports:

- write: 1-byte report id, n-byte payload
- read: n-byte payload

This is differently quirky from the USB HID protocol, which uses the same format for read and write:

- 1-byte report id _if_ more than one report id, n-byte payload

In this case, the devices we deal with only have one report id, so it's redundant in the authenticator-rs write operation -- and the authenticator-rs read operation would be unable to distinguish different report ids, so the assumption of a single report id is baked in and may need nontrivial changes to address if the world grew a FIDO key with multiple report ids for some reason.

In NetBSD, the /dev/uhidN API has the following;

- write: n-byte payload (each uhidN is bound to a single report id)
- read: 1-byte report id if more than one report, n-byte payload => Reads can be requested in any length, but they are queued in atomic units of (optional 1-byte report id plus) exactly the report size.  So for a device with only one report id, a read of exactly the report size will always return a complete report or nothing.

Reports are always 64 bytes in this context.  (Again, various things would fail if this were not the case.)

The ping logic needs to write one report and read one report, which means writing a 65-byte buffer and reading a 64-byte buffer.  Using write_all is harmless but not necessary -- a single write of exactly 65 bytes suffices -- but using read_exact with a 65-byte buffer hangs because the report is only 64 bytes and read_all tries to read more from a device that is in turn waiting for input, leading to deadlock.

This change uses plain write and plain read with exactly the correct sizes to avoid this deadlock.

Note: It is likely that the FreeBSD and OpenBSD transports will need the same treatment but I haven't tested.