### PR TITLE
Use CTAP2 canonical CBOR encoding for PublicKeyCredentialDescriptor

### DIFF
--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -749,28 +749,26 @@ pub mod test {
             0x3,  //allowList
             0x81, // array(1)
             0xa2, // map(2)
-            0x64, // text(4),
-            0x74, 0x79, 0x70, // typ
+            0x62, // text(2)
+            0x69, 0x64, // id
+            0x58, // bytes(
         ]);
         device.add_write(&msg, 0);
 
         msg = cid.to_vec();
         msg.extend([0x0]); //SEQ
-        msg.extend(vec![
-            0x65, // e (continuation of type)
-            0x6a, // text(10)
-            0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79, // public-key
-            0x62, // text(2)
-            0x69, 0x64, // id
-            0x58, 0x40, // bytes(64)
-        ]);
-        msg.extend(&assertion.allow_list[0].id[..42]);
+        msg.extend([0x40]); // 64)
+        msg.extend(&assertion.allow_list[0].id[..58]);
         device.add_write(&msg, 0);
 
         msg = cid.to_vec();
         msg.extend([0x1]); //SEQ
-        msg.extend(&assertion.allow_list[0].id[42..]);
+        msg.extend(&assertion.allow_list[0].id[58..64]);
         msg.extend(vec![
+            0x64, // text(4),
+            0x74, 0x79, 0x70, 0x65, // type
+            0x6a, // text(10)
+            0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, 0x2D, 0x6B, 0x65, 0x79, // public-key
             0x5,  // options
             0xa1, // map(1)
             0x62, // text(2)

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -217,8 +217,8 @@ impl Serialize for PublicKeyCredentialDescriptor {
         //           so we'll leave it out for the moment
         let mut map = serializer.serialize_map(Some(2))?;
         // let mut map = serializer.serialize_map(Some(3))?;
-        map.serialize_entry("type", "public-key")?;
         map.serialize_entry("id", &ByteBuf::from(self.id.clone()))?;
+        map.serialize_entry("type", "public-key")?;
         // map.serialize_entry("transports", &self.transports)?;
         map.end()
     }
@@ -479,11 +479,6 @@ mod test {
             vec![
                 // 0xa3, // map(3)
                 0xa2, // map(2)
-                0x64, // text(4)
-                0x74, 0x79, 0x70, 0x65, // "type"
-                0x6a, // text(10)
-                0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, // "public-key"
-                0x2D, 0x6B, 0x65, 0x79, // ...
                 0x62, // text(2)
                 0x69, 0x64, // "id"
                 0x58, 0x20, // bytes(32)
@@ -492,8 +487,12 @@ mod test {
                 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, // ...
                 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, // ...
                 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, // ...
-                0x1e,
-                0x1f, // ...
+                0x1e, 0x1f, // ...
+                0x64, // text(4)
+                0x74, 0x79, 0x70, 0x65, // "type"
+                0x6a, // text(10)
+                0x70, 0x75, 0x62, 0x6C, 0x69, 0x63, // "public-key"
+                0x2D, 0x6B, 0x65, 0x79, // ...
 
                       // Deactivated for now
                       //0x6a, // text(10)


### PR DESCRIPTION
Resolves [Bug 1823331](https://bugzilla.mozilla.org/show_bug.cgi?id=1823331).

See also #225.