### PR TITLE
Rework CTAP2.0 GetPinToken-workflow

### DIFF
--- a/examples/ctap1.rs
+++ b/examples/ctap1.rs
@@ -118,7 +118,8 @@ fn main() {
             }
             Ok(StatusUpdate::PinError(..))
             | Ok(StatusUpdate::SelectDeviceNotice)
-            | Ok(StatusUpdate::DeviceSelected(..)) => {
+            | Ok(StatusUpdate::DeviceSelected(..))
+            | Ok(StatusUpdate::PinAuthInvalid) => {
                 panic!("STATUS: This can't happen for CTAP1!");
             }
             Err(RecvError) => {

--- a/examples/ctap2.rs
+++ b/examples/ctap2.rs
@@ -129,6 +129,10 @@ fn main() {
                     panic!("Unexpected error: {:?}", e)
                 }
             },
+            Ok(StatusUpdate::PinAuthInvalid) => {
+                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+                continue;
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;
@@ -191,12 +195,8 @@ fn main() {
             register_tx.send(rv).unwrap();
         }));
 
-        if let Err(e) = manager.register(
-            timeout_ms,
-            ctap_args.into(),
-            status_tx.clone(),
-            callback,
-        ) {
+        if let Err(e) = manager.register(timeout_ms, ctap_args.into(), status_tx.clone(), callback)
+        {
             panic!("Couldn't register: {:?}", e);
         };
 
@@ -264,12 +264,7 @@ fn main() {
             sign_tx.send(rv).unwrap();
         }));
 
-        if let Err(e) = manager.sign(
-            timeout_ms,
-            ctap_args.into(),
-            status_tx,
-            callback,
-        ) {
+        if let Err(e) = manager.sign(timeout_ms, ctap_args.into(), status_tx, callback) {
             panic!("Couldn't sign: {:?}", e);
         }
 

--- a/examples/ctap2_discoverable_creds.rs
+++ b/examples/ctap2_discoverable_creds.rs
@@ -32,9 +32,7 @@ fn print_usage(program: &str, opts: Options) {
 fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms: u64) {
     println!();
     println!("*********************************************************************");
-    println!(
-        "Asking a security key to register now with user: {username}"
-    );
+    println!("Asking a security key to register now with user: {username}");
     println!("*********************************************************************");
 
     println!("Asking a security key to register now...");
@@ -99,6 +97,10 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
                     panic!("Unexpected error: {:?}", e)
                 }
             },
+            Ok(StatusUpdate::PinAuthInvalid) => {
+                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+                continue;
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;
@@ -150,12 +152,7 @@ fn register_user(manager: &mut AuthenticatorService, username: &str, timeout_ms:
             register_tx.send(rv).unwrap();
         }));
 
-        if let Err(e) = manager.register(
-            timeout_ms,
-            ctap_args.into(),
-            status_tx,
-            callback,
-        ) {
+        if let Err(e) = manager.register(timeout_ms, ctap_args.into(), status_tx, callback) {
             panic!("Couldn't register: {:?}", e);
         };
 
@@ -287,6 +284,10 @@ fn main() {
                     panic!("Unexpected error: {:?}", e)
                 }
             },
+            Ok(StatusUpdate::PinAuthInvalid) => {
+                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+                continue;
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;
@@ -315,12 +316,7 @@ fn main() {
             sign_tx.send(rv).unwrap();
         }));
 
-        if let Err(e) = manager.sign(
-            timeout_ms,
-            ctap_args.into(),
-            status_tx,
-            callback,
-        ) {
+        if let Err(e) = manager.sign(timeout_ms, ctap_args.into(), status_tx, callback) {
             panic!("Couldn't sign: {:?}", e);
         }
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -118,7 +118,8 @@ fn main() {
             }
             Ok(StatusUpdate::PinError(..))
             | Ok(StatusUpdate::SelectDeviceNotice)
-            | Ok(StatusUpdate::DeviceSelected(..)) => {
+            | Ok(StatusUpdate::DeviceSelected(..))
+            | Ok(StatusUpdate::PinAuthInvalid) => {
                 panic!("STATUS: This can't happen for CTAP1!");
             }
             Err(RecvError) => {

--- a/examples/set_pin.rs
+++ b/examples/set_pin.rs
@@ -114,6 +114,10 @@ fn main() {
                     panic!("Unexpected error: {:?}", e)
                 }
             },
+            Ok(StatusUpdate::PinAuthInvalid) => {
+                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+                continue;
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/examples/test_exclude_list.rs
+++ b/examples/test_exclude_list.rs
@@ -125,6 +125,10 @@ fn main() {
                     panic!("Unexpected error: {:?}", e)
                 }
             },
+            Ok(StatusUpdate::PinAuthInvalid) => {
+                println!("Internal UV usage failed (e.g. using the wrong finger for your fingerprint sensor).");
+                continue;
+            }
             Err(RecvError) => {
                 println!("STATUS: end");
                 return;

--- a/src/ctap2/commands/client_pin.rs
+++ b/src/ctap2/commands/client_pin.rs
@@ -646,33 +646,32 @@ pub enum PinError {
     PinAuthBlocked,
     PinBlocked,
     PinNotSet,
+    /// Used for UV (fingerprints)
+    PinAuthInvalid,
     Crypto(CryptoError),
 }
 
 impl fmt::Display for PinError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            PinError::PinRequired => write!(f, "PinError: Pin required."),
-            PinError::PinIsTooShort => write!(f, "PinError: pin is too short"),
-            PinError::PinIsTooLong(len) => write!(f, "PinError: pin is too long ({len})"),
-            PinError::InvalidKeyLen => write!(f, "PinError: invalid key len"),
+            PinError::PinRequired => write!(f, "Pin required."),
+            PinError::PinIsTooShort => write!(f, "pin is too short"),
+            PinError::PinIsTooLong(len) => write!(f, "pin is too long ({len})"),
+            PinError::InvalidKeyLen => write!(f, "invalid key len"),
             PinError::InvalidPin(ref e) => {
-                let mut res = write!(f, "PinError: Invalid Pin.");
+                let mut res = write!(f, "Invalid Pin.");
                 if let Some(pin_retries) = e {
                     res = write!(f, " Retries left: {pin_retries:?}")
                 }
                 res
             }
-            PinError::PinAuthBlocked => write!(
-                f,
-                "PinError: Pin authentication blocked. Device needs power cycle."
-            ),
-            PinError::PinBlocked => write!(
-                f,
-                "PinError: No retries left. Pin blocked. Device needs reset."
-            ),
-            PinError::PinNotSet => write!(f, "PinError: Pin needed but not set on device."),
-            PinError::Crypto(ref e) => write!(f, "PinError: Crypto backend error: {e:?}"),
+            PinError::PinAuthBlocked => {
+                write!(f, "Pin authentication blocked. Device needs power cycle.")
+            }
+            PinError::PinBlocked => write!(f, "No retries left. Pin blocked. Device needs reset."),
+            PinError::PinNotSet => write!(f, "Pin needed but not set on device."),
+            PinError::PinAuthInvalid => write!(f, "PinAuth invalid."),
+            PinError::Crypto(ref e) => write!(f, "Crypto backend error: {e:?}"),
         }
     }
 }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -1,5 +1,5 @@
 use super::{
-    Command, CommandError, PinAuthCommand, Request, RequestCtap1, RequestCtap2, Retryable,
+    Command, CommandError, PinUvAuthCommand, Request, RequestCtap1, RequestCtap2, Retryable,
     StatusCode,
 };
 use crate::consts::{
@@ -206,7 +206,7 @@ impl GetAssertion {
     }
 }
 
-impl PinAuthCommand for GetAssertion {
+impl PinUvAuthCommand for GetAssertion {
     fn pin(&self) -> &Option<Pin> {
         &self.pin
     }

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -215,10 +215,6 @@ impl PinUvAuthCommand for GetAssertion {
         self.pin = pin;
     }
 
-    fn pin_auth(&self) -> &Option<PinUvAuthParam> {
-        &self.pin_auth
-    }
-
     fn set_pin_auth(&mut self, pin_auth: Option<PinUvAuthParam>) {
         self.pin_auth = pin_auth;
     }

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -150,10 +150,6 @@ impl PinUvAuthCommand for MakeCredentials {
         self.pin = pin;
     }
 
-    fn pin_auth(&self) -> &Option<PinUvAuthParam> {
-        &self.pin_auth
-    }
-
     fn set_pin_auth(&mut self, pin_auth: Option<PinUvAuthParam>) {
         self.pin_auth = pin_auth;
     }

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -1,5 +1,5 @@
 use super::{
-    Command, CommandError, PinAuthCommand, Request, RequestCtap1, RequestCtap2, Retryable,
+    Command, CommandError, PinUvAuthCommand, Request, RequestCtap1, RequestCtap2, Retryable,
     StatusCode,
 };
 use crate::consts::{PARAMETER_SIZE, U2F_REGISTER, U2F_REQUEST_USER_PRESENCE};
@@ -141,7 +141,7 @@ impl MakeCredentials {
     }
 }
 
-impl PinAuthCommand for MakeCredentials {
+impl PinUvAuthCommand for MakeCredentials {
     fn pin(&self) -> &Option<Pin> {
         &self.pin
     }

--- a/src/status_update.rs
+++ b/src/status_update.rs
@@ -13,6 +13,10 @@ pub enum StatusUpdate {
     /// Sent if a PIN is needed (or was wrong), or some other kind of PIN-related
     /// error occurred. The Sender is for sending back a PIN (if needed).
     PinError(PinError, Sender<Pin>),
+    /// This SHOULD ever only happen for CTAP2.0 devices that
+    /// use internal UV (e.g. fingerprint sensors) and failed (e.g. wrong
+    /// finger used).
+    PinAuthInvalid,
     /// Sent, if multiple devices are found and the user has to select one
     SelectDeviceNotice,
     /// Sent, once a device was selected (either automatically or by user-interaction)
@@ -36,6 +40,7 @@ impl Serialize for StatusUpdate {
             StatusUpdate::Success { dev_info } => map.serialize_field("Success", &dev_info)?,
             StatusUpdate::PinError(e, _) => map.serialize_field("PinError", &e)?,
             StatusUpdate::SelectDeviceNotice => map.serialize_field("SelectDeviceNotice", &())?,
+            StatusUpdate::PinAuthInvalid => map.serialize_field("PinAuthInvalid", &())?,
             StatusUpdate::DeviceSelected(dev_info) => {
                 map.serialize_field("DeviceSelected", &dev_info)?
             }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,8 +1,7 @@
 use crate::consts::HIDCmd;
 use crate::crypto::SharedSecret;
-
 use crate::ctap2::commands::client_pin::GetKeyAgreement;
-use crate::ctap2::commands::get_info::{AuthenticatorInfo, GetInfo};
+use crate::ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorVersion, GetInfo};
 use crate::ctap2::commands::get_version::GetVersion;
 use crate::ctap2::commands::make_credentials::dummy_make_credentials_cmd;
 use crate::ctap2::commands::selection::Selection;
@@ -199,9 +198,9 @@ pub trait FidoDevice: HIDDevice {
     }
 
     fn block_and_blink(&mut self, keep_alive: &dyn Fn() -> bool) -> BlinkResult {
-        let supports_select_cmd = self
-            .get_authenticator_info()
-            .map_or(false, |i| i.versions.contains(&String::from("FIDO_2_1")));
+        let supports_select_cmd = self.get_authenticator_info().map_or(false, |i| {
+            i.versions.contains(&AuthenticatorVersion::FIDO_2_1)
+        });
         let resp = if supports_select_cmd {
             let msg = Selection {};
             self.send_cbor_cancellable(&msg, keep_alive)


### PR DESCRIPTION
Trying to rework the GetPinToken-workflow, in order to work for tokens with and without UV.

Tested this with Yubikey BIO.
Would be great to if @andreydanil and @VincentVanlaer could also test this with their ThinC and Mooltipass respectively.

To test, run examples `ctap2` and `ctap2_discoverable_credentials` with this patch and see if
1. the good case works
2. using the wrong finger / PIN will act as expected as well (either repeatedly ask you to touch it, or error out completely after 3 tries).