### PR TITLE
Fix unaligned access warning with rustc 1.69

### DIFF
--- a/src/windows/winapi.rs
+++ b/src/windows/winapi.rs
@@ -221,7 +221,7 @@ impl DeviceInterfaceDetailData {
     }
 
     fn path(&self) -> String {
-        unsafe { from_wide_ptr((*self.data).DevicePath.as_ptr(), self.path_len - 2) }
+        unsafe { from_wide_ptr(ptr::addr_of!((*self.data).DevicePath[0]), self.path_len - 2) }
     }
 }
 


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1826489, whether or not there's a problem in the rust compiler itself.