### PR TITLE
windows: enable winapi std for RawHandle interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
             NATIVE_BUILD: true
             BUILD_OPTIONS: --features crypto_dummy --no-default-features --target=x86_64-pc-windows-gnu
 
+          # Windows MSVC dummy crypto
+          - OS: windows-latest
+            TARGET: x86_64-pc-windows-msvc
+            NATIVE_BUILD: true
+            BUILD_OPTIONS: --features crypto_dummy --no-default-features --target=x86_64-pc-windows-msvc
+
           # FreeBSD - cross compile
           - OS: ubuntu-latest
             TARGET: x86_64-unknown-freebsd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ features = [
     "hidpi",
     "hidusage",
     "setupapi",
+    "std",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
[Cargo resolver 2](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) keeps features enabled only by dev-dependencies out of normal dependencies.

Under resolver 2, a Windows consumer fails at `DeviceCapabilities::new(self.file.as_raw_handle())` because `core::ffi::c_void` and `winapi::ctypes::c_void` are different types. The package's legacy-resolver dev build hides this because `rpassword` enables `winapi/std`.

Enabling `std` on the direct Windows `winapi` dependency makes the raw-handle types compatible without relying on feature unification from an unrelated dev-dependency.

A minimal resolver-2 consumer on Rust 1.97 targeting `x86_64-pc-windows-msvc` fails before this patch and passes afterward. `cargo test --features crypto_dummy --no-default-features` also passes.
