### PR TITLE
Don't use a protocol version that a device doesn't support (#367)

### DIFF
--- a/fuzz/fuzz_targets/u2f_read.rs
+++ b/fuzz/fuzz_targets/u2f_read.rs
@@ -70,10 +70,8 @@ impl<'a> U2FDevice for TestDevice<'a> {
         Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/fuzz/fuzz_targets/u2f_read_write.rs
+++ b/fuzz/fuzz_targets/u2f_read_write.rs
@@ -71,10 +71,8 @@ impl U2FDevice for TestDevice {
         Err(io::Error::new(io::ErrorKind::Other, "Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/authenticatorservice.rs
+++ b/src/authenticatorservice.rs
@@ -25,6 +25,14 @@ pub struct RegisterArgs {
     pub resident_key_req: ResidentKeyRequirement,
     pub extensions: AuthenticationExtensionsClientInputs,
     pub pin: Option<Pin>,
+
+    /// Register the credential using CTAP1/U2F only.
+    ///
+    /// The request [must be compatible with CTAP1 authenticators][0].
+    ///
+    /// This will automatically skip any authenticator that doesn't support CTAP1.
+    ///
+    /// [0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorMakeCredential-interoperability
     pub use_ctap1_fallback: bool,
 }
 
@@ -38,6 +46,14 @@ pub struct SignArgs {
     pub user_presence_req: bool,
     pub extensions: AuthenticationExtensionsClientInputs,
     pub pin: Option<Pin>,
+
+    /// Authenticate using CTAP1/U2F only.
+    ///
+    /// The request [must be compatible with CTAP1 authenticators][0].
+    ///
+    /// This will automatically skip any authenticator that doesn't support CTAP1.
+    ///
+    /// [0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorGetAssertion-interoperability
     pub use_ctap1_fallback: bool,
 }
 

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -939,7 +939,7 @@ pub mod test {
     };
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
-    use crate::transport::{FidoDevice, FidoDeviceIO, FidoProtocol};
+    use crate::transport::{CtapVersionSupport, FidoDevice, FidoDeviceIO, FidoProtocol};
     use crate::u2ftypes::U2FDeviceInfo;
     use rand::{thread_rng, RngCore};
 
@@ -1313,8 +1313,25 @@ pub mod test {
         );
     }
 
+    fn fill_device_ctap1_init(device: &mut Device, cid: [u8; 4]) {
+        // init
+        let mut msg = vec![0xFF, 0xFF, 0xFF, 0xFF]; // broadcast
+        msg.extend([HIDCmd::Init.into(), 0x00, 8]); // cmd + bcnt
+        msg.extend([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // nonce
+        device.add_write(&msg, 0);
+
+        let mut msg = vec![0xFF, 0xFF, 0xFF, 0xFF]; // broadcast
+        msg.extend([0x06, 0x00, 17]); // cmd + bcnt
+        msg.extend([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // nonce
+        msg.extend(&cid);
+        msg.push(2); // CTAPHID protocol version identifir
+        msg.extend([1, 0, 0]); // Device version numbber
+        msg.push(0x01); // CAPABILITY_WINK
+        device.add_read(&msg, 0);
+    }
+
     fn fill_device_ctap1(device: &mut Device, cid: [u8; 4], flags: u8, answer_status: [u8; 2]) {
-        // ctap2 request
+        // ctap1 request
         let mut msg = cid.to_vec();
         msg.extend([HIDCmd::Msg.into(), 0x00, 0x8A]); // cmd + bcnt
         msg.extend([0x00, 0x2]); // U2F_AUTHENTICATE
@@ -1381,13 +1398,15 @@ pub mod test {
             Default::default(),
         );
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
-                                                                         // channel id
-        device.downgrade_to_ctap1();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
+
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
-
-        device.set_cid(cid);
+        fill_device_ctap1_init(&mut device, cid);
+        HIDDevice::pre_init(&mut device).expect("pre_init");
+        assert!(device.supports_ctap1());
+        assert!(!device.supports_ctap2());
+        device.downgrade_to_ctap1().expect("failed to downgrade");
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
 
         // ctap1 request
         fill_device_ctap1(
@@ -1474,13 +1493,15 @@ pub mod test {
         );
 
         let mut device = Device::new("commands/get_assertion").unwrap(); // not really used (all functions ignore it)
-                                                                         // channel id
-        device.downgrade_to_ctap1();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
+
         let mut cid = [0u8; 4];
         thread_rng().fill_bytes(&mut cid);
-
-        device.set_cid(cid);
+        fill_device_ctap1_init(&mut device, cid);
+        HIDDevice::pre_init(&mut device).expect("pre_init");
+        assert!(device.supports_ctap1());
+        assert!(!device.supports_ctap2());
+        device.downgrade_to_ctap1().expect("failed to downgrade");
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
 
         assert_matches!(
             do_credential_list_filtering_ctap1(
@@ -1669,6 +1690,8 @@ pub mod test {
             version_build: 0x08,
             cap_flags: Capability::WINK | Capability::CBOR,
         });
+        assert!(device.supports_ctap1());
+        assert!(device.supports_ctap2());
         device.set_authenticator_info(AuthenticatorInfo {
             versions: vec![AuthenticatorVersion::U2F_V2, AuthenticatorVersion::FIDO_2_0],
             extensions: vec!["uvm".to_string(), "hmac-secret".to_string()],

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -489,13 +489,19 @@ impl PinUvAuthCommand for GetAssertion {
         info: &AuthenticatorInfo,
         uv_req: UserVerificationRequirement,
     ) -> bool {
-        let supports_uv = info.options.user_verification == Some(true);
-        let pin_configured = info.options.client_pin == Some(true);
-        let device_protected = supports_uv || pin_configured;
-        let uv_discouraged = uv_req == UserVerificationRequirement::Discouraged;
-        let always_uv = info.options.always_uv == Some(true);
+        if uv_req == UserVerificationRequirement::Required
+            || info.options.always_uv.unwrap_or(false)
+        {
+            // The RP requires UV, or the authenticator always requires UV (CTAP 2.1 §7.2.2).
+            return false;
+        }
 
-        !always_uv && (!device_protected || uv_discouraged)
+        let uv_discouraged = uv_req == UserVerificationRequirement::Discouraged;
+
+        // The RP "prefers enforcing UV" (CTAP 2.1 §6.2.1 step 1.1) or
+        // "prefers UV ... if possible" (WebAuthn-3 §5.8.6). UV is "possible" on
+        // authenticators that support it, but it might not be configured.
+        uv_discouraged || !info.supports_uv()
     }
 
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {

--- a/src/ctap2/commands/get_assertion.rs
+++ b/src/ctap2/commands/get_assertion.rs
@@ -971,11 +971,11 @@ pub mod test {
             },
             Default::default(),
         );
-        let mut device = Device::new("commands/get_assertion").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
+        let mut device = Device::new_pre_inited(
+            "commands/get_info",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
 
         let mut msg = cid.to_vec();
         msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x90]);

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -637,12 +637,11 @@ impl<'de> Deserialize<'de> for AuthenticatorInfo {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
+    use crate::consts::{Capability, HIDCmd};
     use crate::crypto::COSEAlgorithm;
     use crate::transport::device_selector::Device;
     use crate::transport::platform::device::IN_HID_RPT_SIZE;
     use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol};
-    use rand::{thread_rng, RngCore};
     use serde_cbor::de::from_slice;
 
     // Raw data take from https://github.com/Yubico/python-fido2/blob/master/test/test_ctap2.py
@@ -998,31 +997,11 @@ pub mod tests {
 
     #[test]
     fn test_get_info_ctap2_only() {
-        let mut device = Device::new("commands/get_info").unwrap();
-        let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
-
-        // channel id
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-
-        // init packet
-        let mut msg = CID_BROADCAST.to_vec();
-        msg.extend(vec![HIDCmd::Init.into(), 0x00, 0x08]); // cmd + bcnt
-        msg.extend_from_slice(&nonce);
-        device.add_write(&msg, 0);
-
-        // init_resp packet
-        let mut msg = CID_BROADCAST.to_vec();
-        msg.extend(vec![
-            0x06, /* HIDCmd::Init without TYPE_INIT */
-            0x00, 0x11,
-        ]); // cmd + bcnt
-        msg.extend_from_slice(&nonce);
-        msg.extend_from_slice(&cid); // new channel id
-
-        // We are setting NMSG, to signal that the device does not support CTAP1
-        msg.extend(vec![0x02, 0x04, 0x01, 0x08, 0x01 | 0x04 | 0x08]); // versions + flags (wink+cbor+nmsg)
-        device.add_read(&msg, 0);
+        let mut device = Device::new_pre_inited(
+            "commands/get_info",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
 
         // ctap2 request
         let mut msg = cid.to_vec();

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -90,23 +90,47 @@ pub struct AuthenticatorOptions {
     #[serde(rename = "up", default = "true_val")]
     pub user_presence: bool,
 
-    /// Indicates that the device is capable of verifying the user within
-    /// itself. For example, devices with UI, biometrics fall into this
-    /// category.
-    ///  If present and set to true, it indicates that the device is capable of
-    ///   user verification within itself and has been configured.
-    ///  If present and set to false, it indicates that the device is capable of
-    ///   user verification within itself and has not been yet configured. For
-    ///   example, a biometric device that has not yet been configured will
-    ///   return this parameter set to false.
-    ///  If absent, it indicates that the device is not capable of user
-    ///   verification within itself.
-    /// A device that can only do Client PIN will not return the "uv" parameter.
-    /// If a device is capable of verifying the user within itself as well as
-    /// able to do Client PIN, it will return both "uv" and the Client PIN
-    /// option.
-    // TODO(MS): My Token (key-ID FIDO2) does return Some(false) here, even though
-    //           it has no built-in verification method. Not to be trusted...
+    /// In CTAP 2.1+, indicates that the authenticator supports
+    /// [a built-in user verification method][0].
+    ///
+    /// For example, devices with UI, biometrics fall into this category.
+    ///
+    /// * If `Some(true)`, it indicates that the device is capable of built-in user verification and
+    ///   its user verification feature is presently configured.
+    ///
+    /// * If `Some(false)`, it indicates that the authenticator is capable of built-in user
+    ///   verification and its user verification feature is not presently configured.
+    ///
+    ///   For example, an authenticator featuring a built-in biometric user verification feature
+    ///   that is not presently configured will return this option set to `Some(false)`.
+    ///
+    /// * If `None`, it indicates that the authenticator does not have a built-in user verification
+    ///   capability.
+    ///
+    /// A device that can only do Client PIN will return `None`.
+    ///
+    /// If a device is capable of both built-in user verification and Client PIN, the authenticator
+    /// will return both the "uv" and [the "clientPin"][Self::client_pin] option ids.
+    ///
+    /// ### Caveats
+    ///
+    /// [CTAP 2.0][1] gives the `uv` option a completely different meaning to CTAP 2.1+:
+    ///
+    /// > Indicates that the device is capable of verifying the user as part of the
+    /// > `authenticatorGetAssertion` request. Default: `false`
+    ///
+    /// Some CTAP 2.1-PRE authenticators that _only_ support client PIN erroneously return
+    /// `Some(false)` (eg: Key-ID FIDO2).
+    ///
+    /// ### References
+    ///
+    /// * [CTAP 2.0][1] (different to CTAP 2.1 and later)
+    /// * [CTAP 2.1](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-uv)
+    /// * [CTAP 2.2](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-uv)
+    /// * [CTAP 2.3](https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#getinfo-uv)
+    ///
+    /// [0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#built-in-user-verification-method
+    /// [1]: https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorgetinfo-0x04
     #[serde(rename = "uv")]
     pub user_verification: Option<bool>,
 
@@ -369,8 +393,24 @@ impl AuthenticatorInfo {
         AuthenticatorVersion::U2F_V2
     }
 
+    /// `true` if the device has been configured with [some form of user verification][0]
+    /// (ie: a [client PIN][1] is set and/or [built-in user verification][2] is configured).
+    ///
+    /// [0]: https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#some-form-of-user-verification
+    /// [1]: AuthenticatorOptions::client_pin
+    /// [2]: AuthenticatorOptions::user_verification
     pub fn device_is_protected(&self) -> bool {
         self.options.client_pin == Some(true) || self.options.user_verification == Some(true)
+    }
+
+    /// `true` if the device supports [some form of user verification][0].
+    ///
+    /// This is a mandatory feature on CTAP 2.1+ authenticators that support [resident keys][1]. It
+    ///
+    /// [0]: https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#some-form-of-user-verification
+    /// [1]: AuthenticatorOptions::resident_key
+    pub fn supports_uv(&self) -> bool {
+        self.options.client_pin.is_some() || self.options.user_verification.is_some()
     }
 }
 

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -641,7 +641,7 @@ pub mod tests {
     use crate::crypto::COSEAlgorithm;
     use crate::transport::device_selector::Device;
     use crate::transport::platform::device::IN_HID_RPT_SIZE;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+    use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
     use serde_cbor::de::from_slice;
 
@@ -999,7 +999,6 @@ pub mod tests {
     #[test]
     fn test_get_info_ctap2_only() {
         let mut device = Device::new("commands/get_info").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
 
         // channel id
@@ -1045,6 +1044,16 @@ pub mod tests {
         device.init().expect("Failed to init device");
 
         assert_eq!(device.get_cid(), &cid);
+
+        assert!(!device.supports_ctap1());
+        assert!(device.supports_ctap2());
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
+        device
+            .downgrade_to_ctap1()
+            .expect_err("downgrading to CTAP1 should fail");
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
+        assert!(!device.supports_ctap1());
+        assert!(device.supports_ctap2());
 
         let dev_info = device.get_device_info();
         assert_eq!(

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -1048,9 +1048,12 @@ pub mod tests {
         assert!(!device.supports_ctap1());
         assert!(device.supports_ctap2());
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-        device
-            .downgrade_to_ctap1()
-            .expect_err("downgrading to CTAP1 should fail");
+        assert_matches!(
+            device
+                .downgrade_to_ctap1()
+                .expect_err("downgrading to CTAP1 should fail when NMSG"),
+            HIDError::UnexpectedVersion
+        );
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
         assert!(!device.supports_ctap1());
         assert!(device.supports_ctap2());

--- a/src/ctap2/commands/get_info.rs
+++ b/src/ctap2/commands/get_info.rs
@@ -1037,7 +1037,7 @@ pub mod tests {
         assert!(!device.supports_ctap1());
         assert!(device.supports_ctap2());
 
-        let dev_info = device.get_device_info();
+        let dev_info = device.get_device_info().expect("device info is set");
         assert_eq!(
             dev_info.cap_flags,
             Capability::WINK | Capability::CBOR | Capability::NMSG

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -60,60 +60,19 @@ impl RequestCtap1 for GetVersion {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
+    use crate::consts::Capability;
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol};
-    use rand::{thread_rng, RngCore};
+    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+    use crate::CtapVersionSupport;
 
     #[test]
     fn test_get_version_ctap1_only() {
-        let mut device = Device::new("commands/get_version").unwrap();
-        let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
-
-        // channel id
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-
-        // init packet
-        let mut msg = CID_BROADCAST.to_vec();
-        msg.extend([HIDCmd::Init.into(), 0x00, 0x08]); // cmd + bcnt
-        msg.extend_from_slice(&nonce);
-        device.add_write(&msg, 0);
-
-        // init_resp packet
-        let mut msg = CID_BROADCAST.to_vec();
-        msg.extend(vec![
-            0x06, /* HIDCmd::Init without !TYPE_INIT */
-            0x00, 0x11,
-        ]); // cmd + bcnt
-        msg.extend_from_slice(&nonce);
-        msg.extend_from_slice(&cid); // new channel id
-
-        // We are not setting CBOR, to signal that the device does not support CTAP2
-        msg.extend([0x02, 0x04, 0x01, 0x08, 0x01]); // versions + flags (wink)
-        device.add_read(&msg, 0);
-
-        // ctap1 U2F_VERSION request
-        let mut msg = cid.to_vec();
-        msg.extend([HIDCmd::Msg.into(), 0x0, 0x7]); // cmd + bcnt
-        msg.extend([0x0, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0]);
-        device.add_write(&msg, 0);
-
-        // fido response
-        let mut msg = cid.to_vec();
-        msg.extend([HIDCmd::Msg.into(), 0x0, 0x08]); // cmd + bcnt
-        msg.extend([0x55, 0x32, 0x46, 0x5f, 0x56, 0x32]); // 'U2F_V2'
-        msg.extend(SW_NO_ERROR);
-        device.add_read(&msg, 0);
-
-        device.init().expect("Failed to init device");
-        assert!(device.supports_ctap1());
-        assert!(!device.supports_ctap2());
+        let mut device = Device::new_pre_inited("commands/get_version", Capability::WINK);
 
         device.downgrade_to_ctap1().expect("failed to downgrade");
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
-
-        assert_eq!(device.get_cid(), &cid);
+        assert!(device.supports_ctap1());
+        assert!(!device.supports_ctap2());
 
         let dev_info = device.get_device_info();
         assert_eq!(dev_info.cap_flags, Capability::WINK);

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -74,7 +74,7 @@ pub mod tests {
         assert!(device.supports_ctap1());
         assert!(!device.supports_ctap2());
 
-        let dev_info = device.get_device_info();
+        let dev_info = device.get_device_info().expect("device info is set");
         assert_eq!(dev_info.cap_flags, Capability::WINK);
 
         let result = device.get_authenticator_info();

--- a/src/ctap2/commands/get_version.rs
+++ b/src/ctap2/commands/get_version.rs
@@ -62,14 +62,12 @@ impl RequestCtap1 for GetVersion {
 pub mod tests {
     use crate::consts::{Capability, HIDCmd, CID_BROADCAST, SW_NO_ERROR};
     use crate::transport::device_selector::Device;
-    use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+    use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol};
     use rand::{thread_rng, RngCore};
 
     #[test]
     fn test_get_version_ctap1_only() {
         let mut device = Device::new("commands/get_version").unwrap();
-        device.downgrade_to_ctap1();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
         let nonce = [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01];
 
         // channel id
@@ -91,7 +89,7 @@ pub mod tests {
         msg.extend_from_slice(&nonce);
         msg.extend_from_slice(&cid); // new channel id
 
-        // We are not setting CBOR, to signal that the device does not support CTAP1
+        // We are not setting CBOR, to signal that the device does not support CTAP2
         msg.extend([0x02, 0x04, 0x01, 0x08, 0x01]); // versions + flags (wink)
         device.add_read(&msg, 0);
 
@@ -109,6 +107,11 @@ pub mod tests {
         device.add_read(&msg, 0);
 
         device.init().expect("Failed to init device");
+        assert!(device.supports_ctap1());
+        assert!(!device.supports_ctap2());
+
+        device.downgrade_to_ctap1().expect("failed to downgrade");
+        assert_eq!(device.get_protocol(), FidoProtocol::CTAP1);
 
         assert_eq!(device.get_cid(), &cid);
 

--- a/src/ctap2/commands/large_blobs.rs
+++ b/src/ctap2/commands/large_blobs.rs
@@ -471,12 +471,11 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::consts::HIDCmd;
+    use crate::consts::{Capability, HIDCmd};
     use crate::transport::device_selector::Device;
     use crate::transport::hid::HIDDevice;
     use crate::transport::platform::device::{IN_HID_RPT_SIZE, OUT_HID_RPT_SIZE};
-    use crate::transport::{FidoDevice, FidoProtocol};
-    use rand::{thread_rng, RngCore};
+    use crate::transport::FidoDevice;
 
     fn add_bytes_to_read(cid: &[u8], bytes: &[u8], device: &mut Device) {
         let mut data = Vec::new();
@@ -522,13 +521,11 @@ pub mod tests {
     #[test]
     fn test_read_large_blob_array() {
         let keep_alive = || true;
-        let mut device = Device::new("commands/large_blobs").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-
-        // 'initialize' the device
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
+        let mut device = Device::new_pre_inited(
+            "commands/large_blob",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
 
         let cmd = [
             0xa2, // map(2)
@@ -553,13 +550,11 @@ pub mod tests {
     #[test]
     fn test_read_large_blob_array_with_wrong_hash() {
         let keep_alive = || true;
-        let mut device = Device::new("commands/large_blobs").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-
-        // 'initialize' the device
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
+        let mut device = Device::new_pre_inited(
+            "commands/large_blob",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
 
         let cmd = [
             0xa2, // map(2)
@@ -595,17 +590,15 @@ pub mod tests {
     #[test]
     fn test_read_large_blob_array_multi_read() {
         let keep_alive = || true;
-        let mut device = Device::new("commands/large_blobs").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
+        let mut device = Device::new_pre_inited(
+            "commands/large_blob",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
         device.set_authenticator_info(crate::AuthenticatorInfo {
             max_msg_size: Some(164), // Note: This value minus 64 will be the fragment size
             ..Default::default()
         });
-
-        // 'initialize' the device
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
 
         for ii in 0..5 {
             let mut cmd = vec![
@@ -634,13 +627,11 @@ pub mod tests {
     #[test]
     fn test_add_large_blob_element() {
         let keep_alive = || true;
-        let mut device = Device::new("commands/large_blobs").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-
-        // First we read the whole existing array
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
+        let mut device = Device::new_pre_inited(
+            "commands/large_blob",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
 
         let cmd = [
             0xa2, // map(2)
@@ -684,18 +675,17 @@ pub mod tests {
     #[test]
     fn test_add_large_blob_element_multi_write() {
         let keep_alive = || true;
-        let mut device = Device::new("commands/large_blobs").unwrap();
-        assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
+        let mut device = Device::new_pre_inited(
+            "commands/large_blob",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
         device.set_authenticator_info(crate::AuthenticatorInfo {
             max_msg_size: Some(164), // Note: This value minus 64 will be the fragment size
             ..Default::default()
         });
 
         // First we read the whole existing array
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
-
         for ii in 0..5 {
             let mut cmd = vec![
                 0xa2, // map(2)

--- a/src/ctap2/commands/make_credentials.rs
+++ b/src/ctap2/commands/make_credentials.rs
@@ -498,27 +498,36 @@ impl PinUvAuthCommand for MakeCredentials {
         info: &AuthenticatorInfo,
         uv_req: UserVerificationRequirement,
     ) -> bool {
-        // TODO(MS): Handle here the case where we NEED a UV, the device supports PINs, but hasn't set a PIN.
-        //           For this, the user has to be prompted to set a PIN first (see https://github.com/mozilla/authenticator-rs/issues/223)
+        // TODO(MS): Handle setting up a PIN where needed
+        // (see https://github.com/mozilla/authenticator-rs/issues/223)
+        if uv_req == UserVerificationRequirement::Required
+            || info.options.always_uv.unwrap_or(false)
+        {
+            // The RP requires UV, or the authenticator always requires UV (CTAP 2.1 §7.2.2).
+            return false;
+        }
 
-        let supports_uv = info.options.user_verification == Some(true);
-        let pin_configured = info.options.client_pin == Some(true);
+        // `true` if we'd plan to not use UV (ie: uv option is false and pinUvAuthParam unset)
+        let uv_discouraged = uv_req == UserVerificationRequirement::Discouraged;
+        let make_cred_uv_not_required = info.options.make_cred_uv_not_rqd == Some(true);
+        let rk = self.options.resident_key == Some(true);
 
-        // CTAP 2.0 authenticators require user verification if the device is protected
-        let device_protected = supports_uv || pin_configured;
+        if info.device_is_protected() && (!make_cred_uv_not_required || rk) {
+            // CTAP 2.3 §6.1.2 Step 7 only requires UV for RKs if the device is protected and
+            // supports make_cred_uv_not_rqd.
+            // https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#ref-for-getinfo-makecreduvnotrqd%E2%91%A1
+            //
+            // CTAP 2.3 §6.1.2 Step 8 and CTAP 2.0 §5.1 Step 5 require UV if the device is protected
+            // and does not support make_cred_uv_not_rqd.
+            // https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#ref-for-getinfo-makecreduvnotrqd%E2%91%A2
+            // https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#authenticatorMakeCredential:~:text=If%20pinAuth%20parameter%20is%20not%20present%20and%20clientPin%20been%20set%20on%20the%20authenticator%2C
+            return false;
+        }
 
-        // CTAP 2.1 authenticators may allow the creation of non-discoverable credentials without
-        // user verification. This is only relevant if the relying party has not requested user
-        // verification.
-        let make_cred_uv_not_required = info.options.make_cred_uv_not_rqd == Some(true)
-            && self.options.resident_key != Some(true)
-            && uv_req == UserVerificationRequirement::Discouraged;
-
-        // Alternatively, CTAP 2.1 authenticators may require user verification regardless of the
-        // RP's requirement.
-        let always_uv = info.options.always_uv == Some(true);
-
-        !always_uv && (!device_protected || make_cred_uv_not_required)
+        // The RP "prefers enforcing UV" (CTAP 2.1 §6.1.1 step 1.1) or
+        // "prefers UV ... if possible" (WebAuthn-3 §5.8.6). UV is "possible" on
+        // authenticators that support it, but it might not be configured.
+        uv_discouraged || !info.supports_uv()
     }
 
     fn get_pin_uv_auth_param(&self) -> Option<&PinUvAuthParam> {

--- a/src/ctap2/commands/reset.rs
+++ b/src/ctap2/commands/reset.rs
@@ -52,19 +52,18 @@ impl RequestCtap2 for Reset {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::consts::HIDCmd;
+    use crate::consts::{Capability, HIDCmd};
     use crate::transport::device_selector::Device;
     use crate::transport::{hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
-    use rand::{thread_rng, RngCore};
     use serde_cbor::{de::from_slice, Value};
 
     fn issue_command_and_get_response(cmd: u8, add: &[u8]) -> Result<(), HIDError> {
-        let mut device = Device::new("commands/Reset").unwrap();
+        let mut device = Device::new_pre_inited(
+            "commands/reset",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-        // ctap2 request
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
 
         let mut msg = cid.to_vec();
         msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x1]); // cmd + bcnt

--- a/src/ctap2/commands/selection.rs
+++ b/src/ctap2/commands/selection.rs
@@ -52,20 +52,23 @@ impl RequestCtap2 for Selection {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::consts::HIDCmd;
+    use crate::consts::{Capability, HIDCmd};
     use crate::transport::device_selector::Device;
     use crate::transport::{hid::HIDDevice, FidoDevice, FidoDeviceIO, FidoProtocol};
-    use rand::{thread_rng, RngCore};
+    use crate::CtapVersionSupport;
     use serde_cbor::{de::from_slice, Value};
 
     fn issue_command_and_get_response(cmd: u8, add: &[u8]) -> Result<(), HIDError> {
-        let mut device = Device::new("commands/selection").unwrap();
+        let mut device = Device::new_pre_inited(
+            "commands/get_info",
+            Capability::CBOR | Capability::NMSG | Capability::WINK,
+        );
+        let cid = device.get_cid().clone();
+        assert!(!device.supports_ctap1());
+        assert!(device.supports_ctap2());
         assert_eq!(device.get_protocol(), FidoProtocol::CTAP2);
-        // ctap2 request
-        let mut cid = [0u8; 4];
-        thread_rng().fill_bytes(&mut cid);
-        device.set_cid(cid);
 
+        // ctap2 request
         let mut msg = cid.to_vec();
         msg.extend(vec![HIDCmd::Cbor.into(), 0x00, 0x1]); // cmd + bcnt
         msg.extend(vec![0x0B]); // authenticatorSelection

--- a/src/ctap2/mod.rs
+++ b/src/ctap2/mod.rs
@@ -413,6 +413,37 @@ fn determine_puap_if_needed<Dev: FidoDevice, T: PinUvAuthCommand + RequestCtap2>
     Err(AuthenticatorError::CancelledByUser)
 }
 
+/// Check that the registration request can be processed by a CTAP1 device.
+///
+/// See [CTAP 2.1 §10.2][0].
+///
+/// Some additional checks are performed in `MakeCredentials::RequestCtap1`.
+///
+/// [0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorMakeCredential-interoperability
+pub(crate) fn check_ctap1_register_compatibility(args: &RegisterArgs) -> crate::Result<()> {
+    if args.resident_key_req == ResidentKeyRequirement::Required {
+        return Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::ResidentKey,
+        ));
+    }
+    if args.user_verification_req == UserVerificationRequirement::Required {
+        return Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::UserVerification,
+        ));
+    }
+    if !args
+        .pub_cred_params
+        .iter()
+        .any(|x| x.alg == COSEAlgorithm::ES256)
+    {
+        return Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::PubCredParams,
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn register<Dev: FidoDevice>(
     dev: &mut Dev,
     args: RegisterArgs,
@@ -422,50 +453,33 @@ pub fn register<Dev: FidoDevice>(
 ) -> bool {
     let mut options = MakeCredentialsOptions::default();
 
-    if dev.get_protocol() == FidoProtocol::CTAP2 {
-        let info = match dev.get_authenticator_info() {
-            Some(info) => info,
-            None => {
-                callback.call(Err(HIDError::DeviceNotInitialized.into()));
+    match dev.get_protocol() {
+        FidoProtocol::CTAP2 => {
+            let info = match dev.get_authenticator_info() {
+                Some(info) => info,
+                None => {
+                    callback.call(Err(HIDError::DeviceNotInitialized.into()));
+                    return false;
+                }
+            };
+
+            // Set options based on the arguments and the device info.
+            // The user verification option will be set in `determine_puap_if_needed`.
+            options.resident_key = match args.resident_key_req {
+                ResidentKeyRequirement::Required => Some(true),
+                ResidentKeyRequirement::Preferred => {
+                    // Use a resident key if the authenticator supports it
+                    Some(info.options.resident_key)
+                }
+                ResidentKeyRequirement::Discouraged => Some(false),
+            };
+        }
+
+        FidoProtocol::CTAP1 => {
+            if let Err(e) = check_ctap1_register_compatibility(&args) {
+                callback.call(Err(e));
                 return false;
             }
-        };
-
-        // Set options based on the arguments and the device info.
-        // The user verification option will be set in `determine_puap_if_needed`.
-        options.resident_key = match args.resident_key_req {
-            ResidentKeyRequirement::Required => Some(true),
-            ResidentKeyRequirement::Preferred => {
-                // Use a resident key if the authenticator supports it
-                Some(info.options.resident_key)
-            }
-            ResidentKeyRequirement::Discouraged => Some(false),
-        }
-    } else {
-        // Check that the request can be processed by a CTAP1 device.
-        // See CTAP 2.1 Section 10.2. Some additional checks are performed in
-        // MakeCredentials::RequestCtap1
-        if args.resident_key_req == ResidentKeyRequirement::Required {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::ResidentKey,
-            )));
-            return false;
-        }
-        if args.user_verification_req == UserVerificationRequirement::Required {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::UserVerification,
-            )));
-            return false;
-        }
-        if !args
-            .pub_cred_params
-            .iter()
-            .any(|x| x.alg == COSEAlgorithm::ES256)
-        {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::PubCredParams,
-            )));
-            return false;
         }
     }
 
@@ -588,6 +602,28 @@ pub fn register<Dev: FidoDevice>(
     false
 }
 
+/// Check that the signing request can be processed by a CTAP1 device.
+///
+/// See [CTAP 2.1 §10.3][0].
+///
+/// Some additional checks are performed in `GetAssertion::RequestCtap1`.
+///
+/// [0]: https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#u2f-authenticatorGetAssertion-interoperability
+pub(crate) fn check_ctap1_sign_compatibility(args: &SignArgs) -> crate::Result<()> {
+    if args.user_verification_req == UserVerificationRequirement::Required {
+        return Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::UserVerification,
+        ));
+    }
+    if args.allow_list.is_empty() {
+        return Err(AuthenticatorError::UnsupportedOption(
+            UnsupportedOption::EmptyAllowList,
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn sign<Dev: FidoDevice>(
     dev: &mut Dev,
     args: SignArgs,
@@ -596,19 +632,8 @@ pub fn sign<Dev: FidoDevice>(
     alive: &dyn Fn() -> bool,
 ) -> bool {
     if dev.get_protocol() == FidoProtocol::CTAP1 {
-        // Check that the request can be processed by a CTAP1 device.
-        // See CTAP 2.1 Section 10.3. Some additional checks are performed in
-        // GetAssertion::RequestCtap1
-        if args.user_verification_req == UserVerificationRequirement::Required {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::UserVerification,
-            )));
-            return false;
-        }
-        if args.allow_list.is_empty() {
-            callback.call(Err(AuthenticatorError::UnsupportedOption(
-                UnsupportedOption::EmptyAllowList,
-            )));
+        if let Err(e) = check_ctap1_sign_compatibility(&args) {
+            callback.call(Err(e));
             return false;
         }
     }

--- a/src/ctap2/server.rs
+++ b/src/ctap2/server.rs
@@ -296,10 +296,18 @@ pub enum ResidentKeyRequirement {
     Required,
 }
 
+/// Reference: <https://www.w3.org/TR/webauthn-3/#enum-userVerificationRequirement>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum UserVerificationRequirement {
+    /// The Relying Party does not want user verification employed during the operation (e.g., in
+    /// the interest of minimizing disruption to the user interaction flow).
     Discouraged,
+    /// The Relying Party prefers user verification for the operation if possible, but will not
+    /// fail the operation if the response does not have the UV flag set.
     Preferred,
+    /// The Relying Party requires user verification for the operation and will fail the overall
+    /// ceremony if the response does not have the UV flag set. The client MUST return an error
+    /// if user verification cannot be performed.
     Required,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,9 @@ pub use status_update::{
     BioEnrollmentCmd, CredManagementCmd, InteractiveRequest, InteractiveUpdate, StatusPinUv,
     StatusUpdate,
 };
-pub use transport::{BlinkResult, FidoDevice, FidoDeviceIO, FidoProtocol, VirtualFidoDevice};
+pub use transport::{
+    BlinkResult, CtapVersionSupport, FidoDevice, FidoDeviceIO, FidoProtocol, VirtualFidoDevice,
+};
 
 // Keep this in sync with the constants in u2fhid-capi.h.
 bitflags! {

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -12,7 +12,7 @@ use crate::transport::device_selector::{
     BlinkResult, Device, DeviceBuildParameters, DeviceCommand, DeviceSelectorEvent,
 };
 use crate::transport::platform::transaction::Transaction;
-use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol};
+use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol};
 use crate::{InteractiveRequest, ManageResult};
 use std::sync::mpsc::{channel, RecvTimeoutError, Sender};
 use std::time::Duration;
@@ -118,6 +118,21 @@ impl StateMachine {
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::RegisterResult>>,
     ) {
+        // Could the request be handled by a CTAP1 authenticator?
+        let ctap2_only = {
+            if let Err(e) = ctap2::check_ctap1_register_compatibility(&args) {
+                if args.use_ctap1_fallback {
+                    // There's no way a CTAP1 authenticator could approve this request, so cancel early.
+                    callback.call(Err(e));
+                    return;
+                }
+
+                true
+            } else {
+                false
+            }
+        };
+
         // Abort any prior register/sign calls.
         self.cancel();
         let cbc = callback.clone();
@@ -130,12 +145,25 @@ impl StateMachine {
                     Some(dev) => dev,
                     None => return,
                 };
+
+                if ctap2_only && !dev.supports_ctap2() {
+                    // CTAP1-only authenticator with a CTAP2-only request.
+                    return;
+                }
+
+                if args.use_ctap1_fallback && !dev.supports_ctap1() {
+                    // CTAP2-only authenticator with a CTAP1-only request.
+                    return;
+                }
+
                 if !Self::wait_for_device_selector(&mut dev, &selector, &status, alive) {
                     return;
                 };
 
-                if args.use_ctap1_fallback {
-                    dev.downgrade_to_ctap1();
+                if args.use_ctap1_fallback && dev.downgrade_to_ctap1().is_err() {
+                    // We shouldn't reach this, but not downgrading early lets us use CTAP 2.1
+                    // device selection on devices that support it.
+                    return;
                 }
 
                 info!("Device {:?} continues with the register process", dev.id());
@@ -158,6 +186,20 @@ impl StateMachine {
         status: Sender<crate::StatusUpdate>,
         callback: StateCallback<crate::Result<crate::SignResult>>,
     ) {
+        // Could the request be handled by a CTAP1 authenticator?
+        let ctap2_only = {
+            if let Err(e) = ctap2::check_ctap1_sign_compatibility(&args) {
+                if args.use_ctap1_fallback {
+                    // There's no way a CTAP1 authenticator could approve this request, so cancel early.
+                    callback.call(Err(e));
+                    return;
+                }
+                true
+            } else {
+                false
+            }
+        };
+
         // Abort any prior register/sign calls.
         self.cancel();
         let cbc = callback.clone();
@@ -171,12 +213,25 @@ impl StateMachine {
                     Some(dev) => dev,
                     None => return,
                 };
+
+                if ctap2_only && !dev.supports_ctap2() {
+                    // CTAP1-only authenticator with a CTAP2-only request.
+                    return;
+                }
+
+                if args.use_ctap1_fallback && !dev.supports_ctap1() {
+                    // CTAP2-only authenticator with a CTAP1-only request.
+                    return;
+                }
+
                 if !Self::wait_for_device_selector(&mut dev, &selector, &status, alive) {
                     return;
                 };
 
-                if args.use_ctap1_fallback {
-                    dev.downgrade_to_ctap1();
+                if args.use_ctap1_fallback && dev.downgrade_to_ctap1().is_err() {
+                    // We shouldn't reach this, but not downgrading early lets us use CTAP 2.1
+                    // device selection on devices that support it.
+                    return;
                 }
 
                 info!("Device {:?} continues with the signing process", dev.id());

--- a/src/statemachine.rs
+++ b/src/statemachine.rs
@@ -148,21 +148,25 @@ impl StateMachine {
 
                 if ctap2_only && !dev.supports_ctap2() {
                     // CTAP1-only authenticator with a CTAP2-only request.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 
                 if args.use_ctap1_fallback && !dev.supports_ctap1() {
                     // CTAP2-only authenticator with a CTAP1-only request.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 
                 if !Self::wait_for_device_selector(&mut dev, &selector, &status, alive) {
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 };
 
                 if args.use_ctap1_fallback && dev.downgrade_to_ctap1().is_err() {
                     // We shouldn't reach this, but not downgrading early lets us use CTAP 2.1
                     // device selection on devices that support it.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 
@@ -216,11 +220,13 @@ impl StateMachine {
 
                 if ctap2_only && !dev.supports_ctap2() {
                     // CTAP1-only authenticator with a CTAP2-only request.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 
                 if args.use_ctap1_fallback && !dev.supports_ctap1() {
                     // CTAP2-only authenticator with a CTAP1-only request.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 
@@ -231,6 +237,7 @@ impl StateMachine {
                 if args.use_ctap1_fallback && dev.downgrade_to_ctap1().is_err() {
                     // We shouldn't reach this, but not downgrading early lets us use CTAP 2.1
                     // device selection on devices that support it.
+                    let _ = selector.send(DeviceSelectorEvent::NotAToken(dev.id()));
                     return;
                 }
 

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -182,11 +182,11 @@ pub mod tests {
     use crate::{
         consts::Capability,
         ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorOptions},
-        transport::FidoDevice,
+        transport::{CtapVersionSupport, FidoDevice},
         u2ftypes::U2FDeviceInfo,
     };
 
-    pub(crate) fn gen_info(id: String) -> U2FDeviceInfo {
+    pub(crate) fn gen_info(id: String, cap_flags: Capability) -> U2FDeviceInfo {
         U2FDeviceInfo {
             vendor_name: String::from("ExampleVendor").into_bytes(),
             device_name: id.into_bytes(),
@@ -194,19 +194,24 @@ pub mod tests {
             version_major: 3,
             version_minor: 2,
             version_build: 1,
-            cap_flags: Capability::WINK | Capability::CBOR | Capability::NMSG,
+            cap_flags,
         }
     }
 
     pub(crate) fn make_device_simple_u2f(dev: &mut Device) {
-        dev.set_device_info(gen_info(dev.id()));
+        dev.set_device_info(gen_info(dev.id(), Capability::WINK));
         dev.set_cid([1, 2, 3, 4]); // Need to set something other than broadcast
-        dev.downgrade_to_ctap1();
+        dev.downgrade_to_ctap1().expect("failed to downgrade");
         dev.create_channel();
+        assert!(dev.supports_ctap1());
+        assert!(!dev.supports_ctap2());
     }
 
     pub(crate) fn make_device_with_pin(dev: &mut Device) {
-        dev.set_device_info(gen_info(dev.id()));
+        dev.set_device_info(gen_info(
+            dev.id(),
+            Capability::WINK | Capability::CBOR | Capability::NMSG,
+        ));
         dev.set_cid([1, 2, 3, 4]); // Need to set something other than broadcast
         dev.create_channel();
         let info = AuthenticatorInfo {
@@ -217,6 +222,8 @@ pub mod tests {
             ..Default::default()
         };
         dev.set_authenticator_info(info);
+        assert!(!dev.supports_ctap1());
+        assert!(dev.supports_ctap2());
     }
 
     fn send_i_am_token(dev: &Device, selector: &DeviceSelector) {

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -182,7 +182,8 @@ pub mod tests {
     use crate::{
         consts::Capability,
         ctap2::commands::get_info::{AuthenticatorInfo, AuthenticatorOptions},
-        transport::{CtapVersionSupport, FidoDevice},
+        errors::HIDError,
+        transport::{CtapVersionSupport, FidoDevice, FidoProtocol},
         u2ftypes::U2FDeviceInfo,
     };
 
@@ -205,6 +206,7 @@ pub mod tests {
         dev.create_channel();
         assert!(dev.supports_ctap1());
         assert!(!dev.supports_ctap2());
+        assert_eq!(FidoProtocol::CTAP1, dev.get_protocol());
     }
 
     pub(crate) fn make_device_with_pin(dev: &mut Device) {
@@ -213,6 +215,11 @@ pub mod tests {
             Capability::WINK | Capability::CBOR | Capability::NMSG,
         ));
         dev.set_cid([1, 2, 3, 4]); // Need to set something other than broadcast
+        assert_matches!(
+            dev.downgrade_to_ctap1()
+                .expect_err("downgrading to CTAP1 should fail when NMSG"),
+            HIDError::UnexpectedVersion
+        );
         dev.create_channel();
         let info = AuthenticatorInfo {
             options: AuthenticatorOptions {
@@ -224,6 +231,7 @@ pub mod tests {
         dev.set_authenticator_info(info);
         assert!(!dev.supports_ctap1());
         assert!(dev.supports_ctap2());
+        assert_eq!(FidoProtocol::CTAP2, dev.get_protocol());
     }
 
     fn send_i_am_token(dev: &Device, selector: &DeviceSelector) {

--- a/src/transport/device_selector.rs
+++ b/src/transport/device_selector.rs
@@ -30,6 +30,8 @@ pub enum DeviceSelectorEvent {
     Timeout,
     DevicesAdded(Vec<DeviceID>),
     DeviceRemoved(DeviceID),
+    /// The device is not a CTAP authenticator, or it is not compatible with the request
+    /// (eg: CTAP2-only request with a CTAP1 authenticator).
     NotAToken(DeviceID),
     ImAToken((DeviceID, Sender<DeviceCommand>)),
     SelectedToken(DeviceID),

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -172,10 +172,8 @@ impl HIDDevice for Device {
         Err(io::Error::other("Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/transport/freebsd/device.rs
+++ b/src/transport/freebsd/device.rs
@@ -4,11 +4,11 @@
 
 extern crate libc;
 
-use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::from_unix_result;
 use crate::util::io_err;
@@ -188,12 +188,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
@@ -229,7 +223,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -1,8 +1,8 @@
 use super::TestDevice;
-use crate::consts::{HIDCmd, CID_BROADCAST};
+use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
 use crate::ctap2::commands::{CommandError, RequestCtap1, RequestCtap2, Retryable, StatusCode};
 use crate::transport::errors::{ApduErrorStatus, HIDError};
-use crate::transport::{FidoDevice, FidoDeviceIO, FidoProtocol};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoDeviceIO, FidoProtocol};
 use crate::u2ftypes::{U2FDeviceInfo, U2FHIDCont, U2FHIDInit, U2FHIDInitResp};
 use crate::util::io_err;
 use rand::{thread_rng, RngCore};
@@ -153,6 +153,16 @@ pub trait HIDDevice: FidoDevice + Read + Write {
         };
         trace!("u2f_read({:?}) cmd={:?}: {:04X?}", self.id(), cmd, &data);
         Ok((cmd, data))
+    }
+}
+
+impl<T: HIDDevice> CtapVersionSupport for T {
+    fn supports_ctap1(&self) -> bool {
+        !self.get_device_info().cap_flags.contains(Capability::NMSG)
+    }
+
+    fn supports_ctap2(&self) -> bool {
+        self.get_device_info().cap_flags.contains(Capability::CBOR)
     }
 }
 

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -22,7 +22,7 @@ pub trait HIDDevice: FidoDevice + Read + Write {
     fn new(parameters: Self::BuildParameters) -> Result<Self, (HIDError, Self::Id)>;
     fn id(&self) -> Self::Id;
 
-    fn get_device_info(&self) -> U2FDeviceInfo;
+    fn get_device_info(&self) -> Option<U2FDeviceInfo>;
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo);
 
     // Channel ID management
@@ -158,11 +158,13 @@ pub trait HIDDevice: FidoDevice + Read + Write {
 
 impl<T: HIDDevice> CtapVersionSupport for T {
     fn supports_ctap1(&self) -> bool {
-        !self.get_device_info().cap_flags.contains(Capability::NMSG)
+        self.get_device_info()
+            .is_some_and(|i| !i.cap_flags.contains(Capability::NMSG))
     }
 
     fn supports_ctap2(&self) -> bool {
-        self.get_device_info().cap_flags.contains(Capability::CBOR)
+        self.get_device_info()
+            .is_some_and(|i| i.cap_flags.contains(Capability::CBOR))
     }
 }
 

--- a/src/transport/hid.rs
+++ b/src/transport/hid.rs
@@ -191,6 +191,10 @@ impl<T: HIDDevice + TestDevice> FidoDeviceIO for T {
         keep_alive: &dyn Fn() -> bool,
     ) -> Result<Req::Output, HIDError> {
         debug!("sending {:?} to {:?}", msg, self);
+        if !self.supports_ctap2() {
+            return Err(HIDError::UnexpectedVersion);
+        }
+
         #[cfg(test)]
         {
             if self.skip_serialization() {
@@ -220,6 +224,10 @@ impl<T: HIDDevice + TestDevice> FidoDeviceIO for T {
         keep_alive: &dyn Fn() -> bool,
     ) -> Result<Req::Output, HIDError> {
         debug!("sending {:?} to {:?}", msg, self);
+        if !self.supports_ctap1() {
+            return Err(HIDError::UnexpectedVersion);
+        }
+
         #[cfg(test)]
         {
             if self.skip_serialization() {

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::{Capability, CID_BROADCAST};
+use crate::consts::CID_BROADCAST;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::{hidraw, monitor};
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::fs::OpenOptions;
@@ -171,12 +171,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets replaced by an actual one
         self.cid != CID_BROADCAST
@@ -206,7 +200,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/linux/device.rs
+++ b/src/transport/linux/device.rs
@@ -155,10 +155,8 @@ impl HIDDevice for Device {
         monitor::get_property_linux(&self.path, prop_name)
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -4,11 +4,11 @@
 
 extern crate log;
 
-use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::iokit::*;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use core_foundation::base::*;
 use core_foundation::string::*;
@@ -188,12 +188,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         self.cid != CID_BROADCAST
     }
@@ -220,7 +214,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/macos/device.rs
+++ b/src/transport/macos/device.rs
@@ -172,10 +172,8 @@ impl HIDDevice for Device {
         unsafe { self.get_property_macos(prop_name) }
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -1,13 +1,13 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
+use crate::consts::{HIDCmd, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::ctap2::commands::{CtapResponse, RequestCtap1, RequestCtap2};
 use crate::transport::device_selector::DeviceCommand;
 use crate::transport::TestDevice;
-use crate::transport::{hid::HIDDevice, FidoDevice, FidoProtocol, HIDError};
+use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol, HIDError};
 use crate::u2ftypes::{U2FDeviceInfo, U2FHIDInitResp};
 use std::any::Any;
 use std::collections::VecDeque;
@@ -291,12 +291,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         self.get_cid() != &CID_BROADCAST
     }
@@ -325,7 +319,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -233,8 +233,8 @@ impl HIDDevice for Device {
         Ok(format!("{prop_name} not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {
@@ -335,7 +335,7 @@ impl FidoDevice for Device {
         self.sender.is_some()
     }
 
-    fn get_shared_secret(&self) -> std::option::Option<&SharedSecret> {
+    fn get_shared_secret(&self) -> Option<&SharedSecret> {
         self.shared_secret.as_ref()
     }
 

--- a/src/transport/mock/device.rs
+++ b/src/transport/mock/device.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use crate::consts::{HIDCmd, CID_BROADCAST};
+use crate::consts::{Capability, HIDCmd, CID_BROADCAST};
 use crate::crypto::SharedSecret;
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::ctap2::commands::{CtapResponse, RequestCtap1, RequestCtap2};
@@ -9,6 +9,7 @@ use crate::transport::device_selector::DeviceCommand;
 use crate::transport::TestDevice;
 use crate::transport::{hid::HIDDevice, CtapVersionSupport, FidoDevice, FidoProtocol, HIDError};
 use crate::u2ftypes::{U2FDeviceInfo, U2FHIDInitResp};
+use rand::{thread_rng, RngCore as _};
 use std::any::Any;
 use std::collections::VecDeque;
 use std::hash::{Hash, Hasher};
@@ -95,6 +96,41 @@ impl Device {
             shared_secret: None,
         })
     }
+
+    pub fn new_pre_inited(
+        parameters: <Device as HIDDevice>::BuildParameters,
+        capabilities: Capability,
+    ) -> Device {
+        let mut device = Device::new(parameters).unwrap();
+        let mut cid = [0u8; 4];
+        thread_rng().fill_bytes(&mut cid);
+
+        // init
+        let mut msg = vec![0xFF, 0xFF, 0xFF, 0xFF]; // broadcast
+        msg.extend([HIDCmd::Init.into(), 0x00, 8]); // cmd + bcnt
+        msg.extend([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // nonce
+        device.add_write(&msg, 0);
+
+        let mut msg = vec![0xFF, 0xFF, 0xFF, 0xFF]; // broadcast
+        msg.extend([0x06, 0x00, 17]); // cmd + bcnt
+        msg.extend([0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]); // nonce
+        msg.extend(&cid);
+        msg.push(2); // CTAPHID protocol version identifir
+        msg.extend([1, 0, 0]); // Device version numbber
+        msg.push(capabilities.bits());
+        device.add_read(&msg, 0);
+
+        HIDDevice::pre_init(&mut device).expect("pre_init");
+        assert_eq!(
+            capabilities.contains(Capability::NMSG),
+            !device.supports_ctap1()
+        );
+        assert_eq!(
+            capabilities.contains(Capability::CBOR),
+            device.supports_ctap2()
+        );
+        device
+    }
 }
 
 impl Write for Device {
@@ -131,8 +167,8 @@ impl Read for Device {
 impl Drop for Device {
     fn drop(&mut self) {
         if !std::thread::panicking() {
-            assert!(self.reads.is_empty());
-            assert!(self.writes.is_empty());
+            assert!(self.reads.is_empty(), "unused reads: {:?}", self.reads);
+            assert!(self.writes.is_empty(), "unused writes: {:?}", self.writes);
         }
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -77,6 +77,14 @@ pub enum FidoProtocol {
     CTAP2,
 }
 
+pub trait CtapVersionSupport {
+    /// `true` if the device supports CTAP1/U2F commands, according to the init message.
+    fn supports_ctap1(&self) -> bool;
+
+    /// `true` if the device supports CTAP2 commands, according to the init message.
+    fn supports_ctap2(&self) -> bool;
+}
+
 pub trait FidoDeviceIO {
     fn send_msg<Out, Req: RequestCtap1<Output = Out> + RequestCtap2<Output = Out>>(
         &mut self,
@@ -127,7 +135,7 @@ pub trait TestDevice {
     ) -> Result<Req::Output, HIDError>;
 }
 
-pub trait FidoDevice: FidoDeviceIO
+pub trait FidoDevice: FidoDeviceIO + CtapVersionSupport
 where
     Self: Sized,
     Self: fmt::Debug,
@@ -137,7 +145,12 @@ where
 
     // Check if the device is actually a token
     fn is_u2f(&mut self) -> bool;
-    fn should_try_ctap2(&self) -> bool;
+
+    #[deprecated = "use CtapVersionSupport::supports_ctap2"]
+    fn should_try_ctap2(&self) -> bool {
+        self.supports_ctap2()
+    }
+
     fn get_authenticator_info(&self) -> Option<&AuthenticatorInfo>;
     fn set_authenticator_info(&mut self, authenticator_info: AuthenticatorInfo);
     fn refresh_authenticator_info(&mut self) -> Option<&AuthenticatorInfo> {
@@ -149,15 +162,19 @@ where
         self.get_authenticator_info()
     }
 
-    // `get_protocol()` indicates whether we're using CTAP1 or CTAP2.
-    // Prior to initializing the device, `get_protocol()` should return CTAP2 unless
-    // there's a reason to believe that the device does not support CTAP2 (e.g. if
-    // it's a HID device and it does not have the CBOR capability).
+    /// Indicates whether we're using CTAP1 (U2F) or CTAP2.
+    ///
+    /// Prior to initializing the device, this returns CTAP2. Initialization checks the CBOR
+    /// capability, and automatically downgrades to CTAP1 if that's not supported.
     fn get_protocol(&self) -> FidoProtocol;
 
-    // We do not provide a generic `set_protocol(..)` function as this would have complicated
-    // interactions with the AuthenticatorInfo state.
-    fn downgrade_to_ctap1(&mut self);
+    /// Downgrades the connection to CTAP1/U2F.
+    ///
+    /// Returns [`HIDError::UnexpectedVersion`] if the authenticator does not support CTAP1.
+    ///
+    /// We do not provide a generic `set_protocol(..)` function as this would have complicated
+    /// interactions with the [`AuthenticatorInfo`] state.
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError>;
 
     fn get_shared_secret(&self) -> Option<&SharedSecret>;
     fn set_shared_secret(&mut self, secret: SharedSecret);
@@ -165,19 +182,20 @@ where
     fn init(&mut self) -> Result<(), HIDError> {
         self.pre_init()?;
 
-        if self.should_try_ctap2() {
+        if self.supports_ctap2() {
             let command = GetInfo::default();
             if let Ok(info) = self.send_cbor(&command) {
                 debug!("{:?}", info);
                 if info.max_supported_version() == AuthenticatorVersion::U2F_V2 {
-                    self.downgrade_to_ctap1();
+                    self.downgrade_to_ctap1()?;
                 }
                 self.set_authenticator_info(info);
                 return Ok(());
             }
         }
 
-        self.downgrade_to_ctap1();
+        // If the device sets NMSG, this will fail.
+        self.downgrade_to_ctap1()?;
         // We want to return an error here if this device doesn't support CTAP1,
         // so we send a U2F_VERSION command.
         let command = GetVersion::default();
@@ -187,9 +205,9 @@ where
 
     fn block_and_blink(&mut self, keep_alive: &dyn Fn() -> bool) -> BlinkResult {
         let supports_select_cmd = self.get_protocol() == FidoProtocol::CTAP2
-            && self.get_authenticator_info().is_some_and(|i| {
-                i.versions.contains(&AuthenticatorVersion::FIDO_2_1)
-            });
+            && self
+                .get_authenticator_info()
+                .is_some_and(|i| i.versions.contains(&AuthenticatorVersion::FIDO_2_1));
         let resp = if supports_select_cmd {
             let msg = Selection {};
             self.send_cbor_cancellable(&msg, keep_alive)

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -79,9 +79,13 @@ pub enum FidoProtocol {
 
 pub trait CtapVersionSupport {
     /// `true` if the device supports CTAP1/U2F commands, according to the init message.
+    ///
+    /// Returns `false` if the device has not sent an init message.
     fn supports_ctap1(&self) -> bool;
 
     /// `true` if the device supports CTAP2 commands, according to the init message.
+    ///
+    /// Returns `false` if the device has not sent an init message.
     fn supports_ctap2(&self) -> bool;
 }
 

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::fd::Fd;
 use crate::transport::platform::monitor::WrappedOpenDevice;
 use crate::transport::platform::uhid;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::io_err;
 use std::ffi::OsString;
@@ -190,12 +190,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
@@ -242,7 +236,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/netbsd/device.rs
+++ b/src/transport/netbsd/device.rs
@@ -174,10 +174,8 @@ impl HIDDevice for Device {
         Err(io::Error::other("Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 extern crate libc;
-use crate::consts::{Capability, CID_BROADCAST, MAX_HID_RPT_SIZE};
+use crate::consts::{CID_BROADCAST, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
 use crate::transport::platform::monitor::WrappedOpenDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use crate::util::{from_unix_result, io_err};
 use std::ffi::{CString, OsString};
@@ -171,12 +171,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
@@ -218,7 +212,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/openbsd/device.rs
+++ b/src/transport/openbsd/device.rs
@@ -155,10 +155,8 @@ impl HIDDevice for Device {
         Err(io::Error::other("Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -63,7 +63,7 @@ impl HIDDevice for Device {
         unimplemented!();
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
         unimplemented!();
     }
 

--- a/src/transport/stub/device.rs
+++ b/src/transport/stub/device.rs
@@ -77,10 +77,6 @@ impl FidoDevice for Device {
         unimplemented!();
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        unimplemented!();
-    }
-
     fn initialized(&self) -> bool {
         unimplemented!();
     }
@@ -109,7 +105,7 @@ impl FidoDevice for Device {
         unimplemented!()
     }
 
-    fn downgrade_to_ctap1(&mut self) {
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
         unimplemented!()
     }
 }

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::winapi::DeviceCapabilities;
-use crate::consts::{
-    Capability, CID_BROADCAST, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID, MAX_HID_RPT_SIZE,
-};
+use crate::consts::{CID_BROADCAST, FIDO_USAGE_PAGE, FIDO_USAGE_U2FHID, MAX_HID_RPT_SIZE};
 use crate::ctap2::commands::get_info::AuthenticatorInfo;
 use crate::transport::hid::HIDDevice;
-use crate::transport::{FidoDevice, FidoProtocol, HIDError, SharedSecret};
+use crate::transport::{CtapVersionSupport, FidoDevice, FidoProtocol, HIDError, SharedSecret};
 use crate::u2ftypes::U2FDeviceInfo;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
@@ -129,12 +127,6 @@ impl FidoDevice for Device {
         HIDDevice::pre_init(self)
     }
 
-    fn should_try_ctap2(&self) -> bool {
-        HIDDevice::get_device_info(self)
-            .cap_flags
-            .contains(Capability::CBOR)
-    }
-
     fn initialized(&self) -> bool {
         // During successful init, the broadcast channel id gets repplaced by an actual one
         self.cid != CID_BROADCAST
@@ -167,7 +159,12 @@ impl FidoDevice for Device {
         self.protocol
     }
 
-    fn downgrade_to_ctap1(&mut self) {
-        self.protocol = FidoProtocol::CTAP1;
+    fn downgrade_to_ctap1(&mut self) -> Result<(), HIDError> {
+        if self.supports_ctap1() {
+            self.protocol = FidoProtocol::CTAP1;
+            Ok(())
+        } else {
+            Err(HIDError::UnexpectedVersion)
+        }
     }
 }

--- a/src/transport/windows/device.rs
+++ b/src/transport/windows/device.rs
@@ -111,10 +111,8 @@ impl HIDDevice for Device {
         Err(io::Error::other("Not implemented"))
     }
 
-    fn get_device_info(&self) -> U2FDeviceInfo {
-        // unwrap is okay, as dev_info must have already been set, else
-        // a programmer error
-        self.dev_info.clone().unwrap()
+    fn get_device_info(&self) -> Option<U2FDeviceInfo> {
+        self.dev_info.clone()
     }
 
     fn set_device_info(&mut self, dev_info: U2FDeviceInfo) {


### PR DESCRIPTION
**Draft PR, needs #374**

This makes `authenticator-rs` never try to use CTAP1 / U2F on devices that won't support it (#367), and also never try to use CTAP2 on devices that won't support it (#371, repeat of #72).

API changes:

* `FidoDevice` now requires (new) `CtapVersionSupport` trait. There is an impl for `T: HIDDevice`.

* **Replaced, with alias:** `FidoDevice::should_try_ctap2()` is moved and renamed to `CtapVersionSupport::supports_ctap2()`. There is an alias for the old name. This replaces the duplicated definition of the function for each platform.

* **Added:** `CtapVersionSupport::supports_ctap1()`, which checks for `CAPABILITY_NMSG` being _unset_.

* **Changed:** `FidoDevice::downgrade_to_ctap1()` is now a fallible operation (returns `Result`), based on `CtapVersionSupport::supports_ctap1()`.

Using `supports_ctap1()` fixes some incorrect behaviour:

[^req-ctap2]: eg: `uv = required`, `rk = required`, not supporting ES256, etc.
[^selected]: selected implicitly, as the only device, or selected explicitly among multiple devices with a button press

* CTAP2-only[^req-ctap2] `register()` or `sign()` requests with `use_ctap1_fallback = true` (`security.webauthn.ctap2 = false`):

  The request will now immediately error out with `UnsupportedOption(...)` (or `NotAllowedError` in Firefox), rather than attempting device selection _and then_ erroring out (with the same error).

* CTAP2-only[^req-ctap2] `register()` or `sign()` requests:

  CTAP1-only devices will now be completely ignored, rather than trying device selection _and then_ erroring out if the CTAP1-only device is selected [^selected].

    This also excludes CTAP1-only devices that _don't_ enforce user presence checks (like U2F NitroKeys that don't have a button), which would otherwise "capture" the request and then prevent use of a CTAP2 authenticator.

* CTAP1-compatible `register()` or `sign()` requests with `use_ctap1_fallback = true` (`security.webauthn.ctap2 = false`):

  CTAP2-only devices will now be completely ignored, rather than trying device selection _and then_ sending them an invalid command (which would probably error out) if selected [^selected].

When a device is ignored, it won't blink or respond to button press. This may lead a user to believe some of their devices are not working. Immediately erroring for impossible requests may lead a user to believe there is a browser bug.

However, prompting for a button press on a device that definitely won't work will just return an error anyway, and doesn't give the user clues about which of their authenticators would actually work.

There may be better ways to handle that (eg: "there are 2 devices connected, but none of them can handle this request"), but it'd require significant API and UI changes to support it, and risks being annoying (eg: corporate-issued devices that have an always-present nano-key that only supports CTAP1).

While here, I've added some more documentation, and fixed some incorrect comments.

Fixes #367, which is required to implement caBLE support in Firefox.

Fixes #371.

### TODO (for me)

- [ ] **Bug:** When there is a CTAP2-only authenticator initially connected, CTAP1 fallback mode doesn't consider other devices that are already connected or connected later.
- [ ] Test this with some real authenticators on different platforms
- [x] Test this inside of Firefox
- [x] Add a `supports_ctap2()` guard to `send_cbor_cancellable`. There are a bunch of CTAP2 tests that use the device without initialising first, causing `mock::HIDDevice::get_device_info` to panic.
- [x] Add a `supports_ctap1()` guard to `send_ctap1_cancellable`.
- [x] Consider making `HidDevice::get_device_info` return an optional, rather than panicing.
- [x] Update `authrs_bridge::TestToken` (which uses `FidoDevice` but not `HIDDevice`) ▶️ https://bugzilla.mozilla.org/show_bug.cgi?id=2065013
